### PR TITLE
fix: update contact links

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -368,7 +368,7 @@
               <div class="col-sm-12">
                 <div class="faq-intro text-center">
                   <h1>Perguntas frequentes (FAQ)</h1>
-                  <p>Caso sua dúvida não seja respondida abaixo, entre em contato conosco por <a href="mailto:contato@ufabcnext.com">email</a></p>
+                  <p>Caso sua dúvida não seja respondida abaixo, entre em contato conosco através do <a href="https://www.instagram.com/ufabc_next/?hl=pt-br">Instagram</a></p>
                 </div>
                 <div data-accordion-group class="accordion-box">
                   <div class="accordion" data-accordion>
@@ -388,7 +388,7 @@
                   <div class="accordion" data-accordion>
                       <div data-control><span><i class="icon-bar"></i></span><h2>Posso confiar no UFABC Next?</h2></div>
                       <div data-content>
-                          <p>Com certeza! Todo <a href="https://github.com/ufabc-next" target="_blank">código do projeto</a> é open source (código aberto), logo qualquer um pode ver o que estamos fazendo e contribuir :) <br /> <br />Caso queira contribuir de alguma forma, entre em contato conosco por <a href="mailto:contato@ufabcnext.com">email</a> </p>
+                          <p>Com certeza! Todo <a href="https://github.com/ufabc-next" target="_blank">código do projeto</a> é open source (código aberto), logo qualquer um pode ver o que estamos fazendo e contribuir :) <br /> <br />Caso queira contribuir de alguma forma, entre em contato conosco do <a href="https://www.instagram.com/ufabc_next/?hl=pt-br">Instagram</a></p>
                       </div>
                   </div>
 


### PR DESCRIPTION
## Descrição

Como o objetivo é centralizar o [Instagram](https://www.instagram.com/ufabc_next/?hl=pt-br ) como canal de comunicação do UFABC Next, também atualizei os links de contato na sessão de FAQ do site principal conforme indicado na reunião do dia 19/08.