### PR TITLE
fix: queryprovider not found

### DIFF
--- a/apps/react/webpack.config.js
+++ b/apps/react/webpack.config.js
@@ -41,7 +41,6 @@ module.exports = {
       exposes: {
         './HelloWorld': './src/components/HelloWorld.tsx',
         './Test': './src/components/Test.tsx',
-        './QueryProvider': './src/components/QueryProvider.tsx',
       },
       shared: dependencies,
     }),


### PR DESCRIPTION
## Descrição

O projeto não estava rodando por conta de alguns arquivos que estavam sendo procurados pelo compilador mas que não existiam mais.