### PR TITLE
perf: vue store

### DIFF
--- a/apps/container/src/store/useAuth.ts
+++ b/apps/container/src/store/useAuth.ts
@@ -1,0 +1,5 @@
+import { authStore } from 'stores';
+import create from 'vue-zustand';
+
+const useAuth = create(authStore);
+export default useAuth

--- a/apps/container/src/views/PerformanceView.vue
+++ b/apps/container/src/views/PerformanceView.vue
@@ -9,11 +9,8 @@
 </template>
 <script setup lang="ts">
 import { defineFederatedReactComponent } from '@/utils/moduleFederation';
+import useAuth from '@/store/useAuth'
 
-import { authStore } from 'stores';
-import create from 'vue-zustand';
-
-const useAuth = create(authStore);
 const { user } = useAuth();
 
 const HelloWorld = defineFederatedReactComponent({

--- a/apps/react/webpack.config.js
+++ b/apps/react/webpack.config.js
@@ -41,7 +41,6 @@ module.exports = {
       exposes: {
         './HelloWorld': './src/components/HelloWorld.tsx',
         './Test': './src/components/Test.tsx',
-        './QueryProvider': './src/components/QueryProvider.tsx',
       },
       shared: dependencies,
     }),


### PR DESCRIPTION
## Descrição
Conforme sugerido, desenvolvi o singleton para evitar a criação de múltiplas instâncias de stores do vue-zustand cada vez que fosse necessário utilizar.

Entretanto, conforme mostrado no exemplo que refatorei do HistoryView, ainda tenho a leve impressão que, ao importar o usuário no componente, estamos também criando uma nova store.

As alterações deste PR estão inclusas no PR da página de configurações -> (#140)

Deixo em aberto para sugestões com o pensamento orientado à performance e otimização de memória.
