### PR TITLE
chore: change instagram url from Recovery alert

### DIFF
--- a/web/src/pages/Recovery/Recovery.html
+++ b/web/src/pages/Recovery/Recovery.html
@@ -29,7 +29,7 @@
                   show-icon>
                   <slot name="title">
                     <div class="pa-2">
-                      Caso você não tenha recebido o email de recuperação de conta, envie uma DM para nosso <a href="https://www.instagram.com/ufabcnext/?hl=pt-br">Instagram</a> e te atenderemos!
+                      Caso você não tenha recebido o email de recuperação de conta, envie uma DM para nosso <a href="https://www.instagram.com/ufabc_next/?hl=pt-br">Instagram</a> e te atenderemos!
                       <br /><br />
                       Não esqueça de informar seu RA e email institucional
                     </div>


### PR DESCRIPTION
### Contexto
Vi que o @mateusbrg corrigiu o link do instagram só de um dos lugares, mas faltou a do alert da página de Recovery também. Esse PR muda de `ufabcnext` para `ufabc_next`.

Sugiro como uma alteração de Design colocar em evidência o Instagram da página na dashboard :smiley: 