### PR TITLE
fix: query duplicate requests

### DIFF
--- a/apps/container/package.json
+++ b/apps/container/package.json
@@ -18,6 +18,7 @@
     "@mdi/font": "7.3.67",
     "@tanstack/query-core": "5.4.3",
     "@tanstack/vue-query": "5.4.3",
+    "@tanstack/vue-query-devtools": "^5.8.4",
     "@vee-validate/zod": "4.11.8",
     "axios": "1.6.0",
     "core-js": "3.33.1",
@@ -62,9 +63,9 @@
     "husky": "8.0.3",
     "jsdom": "22.1.0",
     "lint-staged": "15.0.2",
-    "typescript": "5.2.2",
     "msw": "^2.0.1",
     "types": "*",
+    "typescript": "5.2.2",
     "vitest": "0.34.6"
   },
   "gitHooks": {

--- a/apps/container/src/App.vue
+++ b/apps/container/src/App.vue
@@ -1,4 +1,5 @@
 <template>
+  <VueQueryDevtools />
   <AppBar :showAppBar="confirmedUser ?? undefined">
     <v-main style="background-color: #f5f5f5">
       <v-container
@@ -18,6 +19,7 @@ import { authStore } from 'stores';
 import { computed, onMounted } from 'vue';
 import create from 'vue-zustand';
 import { ElMessage } from 'element-plus';
+import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
 
 import { useRouter } from 'vue-router';
 

--- a/apps/container/src/components/PendingReviewEnrollmentList/PendingReviewEnrollmentList.vue
+++ b/apps/container/src/components/PendingReviewEnrollmentList/PendingReviewEnrollmentList.vue
@@ -32,7 +32,7 @@ import { Enrollment } from 'types';
 
 const { data: enrollments, isError: isErrorEnrollment } = useQuery({
   refetchOnWindowFocus: false,
-  queryKey: ['enrollment', 'list'],
+  queryKey: ['enrollments', 'list'],
   queryFn: Enrollments.list,
   select: (response) => response.data,
 });

--- a/apps/container/src/components/ReviewsWelcome/ReviewsWelcome.vue
+++ b/apps/container/src/components/ReviewsWelcome/ReviewsWelcome.vue
@@ -1,6 +1,6 @@
 <template>
   <div style="max-width: 750px">
-    <div class="mb-6">Como funciona o UFABC Next e os Reviews?</div>
+    <p class="mb-6">Como funciona o UFABC Next e os Reviews?</p>
     <v-layout row wrap>
       <v-row>
         <v-col cols="12" xs="12" sm="5" class="welcome-image">

--- a/apps/container/src/components/SearchBar/SearchBar.vue
+++ b/apps/container/src/components/SearchBar/SearchBar.vue
@@ -68,7 +68,7 @@
 import { useQuery } from '@tanstack/vue-query';
 import debounce from 'lodash.debounce';
 import { Reviews } from 'services';
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { FeedbackAlert } from '@/components/FeedbackAlert';
 import type { SearchTeacherItem, SearchSubjectItem } from 'types';
 import { useRouter } from 'vue-router';
@@ -124,6 +124,7 @@ const handleUpdateDebouncedQuery = debounce(() => {
   debouncedQuery.value = query.value;
 }, 500);
 
+
 const onChangeQuery = (e: InputEvent) => {
   router.replace({
     name: 'reviews',
@@ -133,6 +134,10 @@ const onChangeQuery = (e: InputEvent) => {
   });
   handleUpdateDebouncedQuery();
 };
+
+onMounted(() => {
+  debouncedQuery.value = query.value;
+});
 
 const mapSearchResults = (
   type: string,

--- a/apps/container/src/components/SearchBar/SearchBar.vue
+++ b/apps/container/src/components/SearchBar/SearchBar.vue
@@ -3,10 +3,10 @@
   <FeedbackAlert v-if="isErrorSubjects" text="Erro ao buscar disciplinas" />
   <div class="wrapper w-100 mb-5">
     <v-text-field
+      v-model="query"
+      @input="onChangeQuery"
       variant="solo"
-      v-model="searchTerm"
       placeholder="Digite o nome do professor ou disciplina"
-      @input="search"
       class="mb-1"
       hide-details
       :prepend-inner-icon="
@@ -68,39 +68,23 @@
 import { useQuery } from '@tanstack/vue-query';
 import debounce from 'lodash.debounce';
 import { Reviews } from 'services';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref } from 'vue';
 import { FeedbackAlert } from '@/components/FeedbackAlert';
 import type { SearchTeacherItem, SearchSubjectItem } from 'types';
 import { useRouter } from 'vue-router';
 
 const router = useRouter();
-
-const searchTerm = ref('');
+const query = computed(() => router.currentRoute.value.query.q as string);
 
 const clear = () => {
-  searchTerm.value = '';
   router.replace({
     name: 'reviews',
   });
 };
 
-const query = computed(() => router.currentRoute.value.query.q as string);
-
-onMounted(() => {
-  searchTerm.value = query.value;
-});
-
-watch(
-  () => query.value,
-  (q) => {
-    searchTerm.value = q;
-  },
-);
-
 const enterSearch = (id: string, type: string, name: string) => {
   (document.activeElement as HTMLDivElement)?.blur();
 
-  searchTerm.value = name;
   router.replace({
     name: 'reviews',
     query: {
@@ -111,43 +95,43 @@ const enterSearch = (id: string, type: string, name: string) => {
   });
 };
 
+const debouncedQuery = ref('');
+const enableQuery = computed(() => !!debouncedQuery.value);
+
 const {
   isError: isErrorTeachers,
   isFetching: isFetchingTeachers,
   data: searchResultsTeachers,
-  refetch: refetchTeachers,
 } = useQuery({
   refetchOnWindowFocus: false,
-  queryKey: ['reviews', 'search', query.value, 'teachers'],
-  queryFn: () => Reviews.searchTeachers(query.value),
-  enabled: !!query.value,
+  queryKey: ['reviews', 'search', debouncedQuery, 'teachers'],
+  queryFn: () => Reviews.searchTeachers(debouncedQuery.value),
+  enabled: enableQuery,
 });
 
 const {
   isError: isErrorSubjects,
   isFetching: isFetchingSubjects,
   data: searchResultsSubjects,
-  refetch: refetchSubjects,
 } = useQuery({
   refetchOnWindowFocus: false,
-  queryKey: ['reviews', 'search', query.value, 'subjects'],
-  queryFn: () => Reviews.searchSubjects(query.value),
-  enabled: !!query.value,
+  queryKey: ['reviews', 'search', debouncedQuery, 'subjects'],
+  queryFn: () => Reviews.searchSubjects(debouncedQuery.value),
+  enabled: enableQuery,
 });
 
-const useSearch = debounce(() => {
-  refetchTeachers();
-  refetchSubjects();
+const handleUpdateDebouncedQuery = debounce(() => {
+  debouncedQuery.value = query.value;
 }, 500);
 
-const search = (e: InputEvent) => {
+const onChangeQuery = (e: InputEvent) => {
   router.replace({
     name: 'reviews',
     query: {
       q: (e.target as HTMLInputElement)?.value,
     },
   });
-  useSearch();
+  handleUpdateDebouncedQuery();
 };
 
 const mapSearchResults = (

--- a/apps/container/src/components/WelcomeMessage/WelcomeMessage.test.ts
+++ b/apps/container/src/components/WelcomeMessage/WelcomeMessage.test.ts
@@ -5,9 +5,7 @@ describe('<WelcomeMessage />', () => {
   test('render welcome messages and next benefits', () => {
     render(WelcomeMessage);
     expect(
-      screen.getByRole('heading', {
-        name: 'Como funciona o UFABC Next e os Reviews?',
-      }),
+      screen.getByText('Como funciona o UFABC Next e os Reviews?'),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/Centralização da informação/i),

--- a/apps/container/src/components/WelcomeMessage/WelcomeMessage.vue
+++ b/apps/container/src/components/WelcomeMessage/WelcomeMessage.vue
@@ -1,6 +1,6 @@
 <template>
   <div style="max-width: 750px">
-    <h6 class="mb-6">Como funciona o UFABC Next e os Reviews?</h6>
+    <p class="mb-6">Como funciona o UFABC Next e os Reviews?</p>
     <v-layout row wrap>
       <v-row>
         <v-col cols="12" xs="12" sm="5" class="welcome-image">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,12 +2039,24 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.4.3.tgz#fbdd36ccf1acf70579980f2e7cf16d2c2aa2a5e9"
   integrity sha512-fnI9ORjcuLGm1sNrKatKIosRQUpuqcD4SV7RqRSVmj8JSicX2aoMyKryHEBpVQvf6N4PaBVgBxQomjsbsGPssQ==
 
+"@tanstack/query-devtools@5.8.4":
+  version "5.8.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.8.4.tgz#88849bd27b7c8fa9034f95d24d58c3b82e182269"
+  integrity sha512-F1dRbITNt9tMUoM9WCH8WQ2c54116hv52m/PKK8ZiN/pO2wGVzTZtKuLanF8pFpwmNchjIixcMw/a57HY5ivcw==
+
 "@tanstack/react-query@5.4.3":
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.4.3.tgz#cf59120690032e44b8c1c4c463cfb43aaad2fc5f"
   integrity sha512-4aSOrRNa6yEmf7mws5QPTVMn8Lp7L38tFoTZ0c1ZmhIvbr8GIA0WT7X5N3yz/nuK8hUtjw9cAzBr4BPDZZ+tzA==
   dependencies:
     "@tanstack/query-core" "5.4.3"
+
+"@tanstack/vue-query-devtools@^5.8.4":
+  version "5.8.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/vue-query-devtools/-/vue-query-devtools-5.8.4.tgz#4f30fe0726658fae5bf32bdeefd938770937cc46"
+  integrity sha512-5hgGOuA4e0WYV0yGHaBMO9FFnQCmp4MYjJg02nC2OjW5i7rtLu8VzYVQmbjhNZsBKs7083ZCCC5a077gZm50ew==
+  dependencies:
+    "@tanstack/query-devtools" "5.8.4"
 
 "@tanstack/vue-query@5.4.3":
   version "5.4.3"


### PR DESCRIPTION
- [x] Padroniza as query keys de enrollments.list que estavam diferentes nas duas ocasiões que era chamada
- [x] Refaz a lógica da pesquisa de professores e disciplinas, para reaproveitar o cache da requisições
- [x] Adiciona o VueQueryDevtools para melhor visualização das requests feitas pelo tanstack query
- [x] Conserta tamanho de texto nos componentes de boas vindas