### PR TITLE
perf: use dynamic import on routes

### DIFF
--- a/apps/container/babel.config.js
+++ b/apps/container/babel.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   presets: ['@vue/cli-plugin-babel/preset'],
-  plugins: ['@babel/plugin-transform-private-methods'],
+  plugins: [
+    '@babel/plugin-transform-private-methods',
+    '@babel/plugin-syntax-dynamic-import',
+  ],
 };

--- a/apps/container/package.json
+++ b/apps/container/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@babel/plugin-transform-private-methods": "7.22.5",
     "@babel/preset-env": "7.23.2",
+    "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@testing-library/jest-dom": "6.1.4",
     "@testing-library/user-event": "14.5.1",
     "@testing-library/vue": "7.0.0",

--- a/apps/container/src/components/TeacherReview/TeacherReview.test.ts
+++ b/apps/container/src/components/TeacherReview/TeacherReview.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@/test-utils';
 import { TeacherReview } from '.';
 import { useRouter } from 'vue-router';
-import { concepts, teacherSearch } from '@/mocks/reviews';
+import { teacherSearch } from '@/mocks/reviews';
 import { HttpResponse, http } from 'msw';
 import { server } from '@/mocks/server';
 
@@ -14,8 +14,6 @@ vi.mock('vue-router', async () => ({
 }));
 
 const replaceMock = vi.fn();
-
-const total = Object.values(concepts).reduce((acc, curr) => acc + curr, 0);
 
 describe('<TeacherReview />', () => {
   beforeEach(() => {
@@ -32,41 +30,6 @@ describe('<TeacherReview />', () => {
         },
       },
     } as unknown as ReturnType<typeof useRouter>);
-  });
-
-  test.skip('render teacher review', async () => {
-    vi.mocked(useRouter).mockReturnValue({
-      useRouter: vi.fn(),
-      createRouter: vi.fn(() => ({
-        beforeEach: vi.fn(),
-      })),
-      replace: replaceMock,
-      currentRoute: {
-        value: {
-          query: {
-            q: teacherSearch.data[0].name,
-            teacherId: teacherSearch.data[0]._id,
-          },
-        },
-      },
-    } as unknown as ReturnType<typeof useRouter>);
-
-    render(TeacherReview, {
-      props: {
-        teacherId: teacherSearch.data[0]._id,
-      },
-    });
-    expect(
-      await screen.findByText(/Provavelmente esse professor cobra presença/i),
-    ).toBeInTheDocument();
-
-    Object.values(concepts).forEach(async (concept) => {
-      expect(
-        await screen.findByText(
-          RegExp(((100 * concept) / total).toFixed(1), 'i'),
-        ),
-      ).toBeInTheDocument();
-    });
   });
   test('fetching teacher error toaster', async () => {
     server.use(

--- a/apps/container/src/router/index.ts
+++ b/apps/container/src/router/index.ts
@@ -1,17 +1,18 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
-import { ReviewsView } from '@/views/Reviews';
-import { PerformanceView } from '@/views/Performance';
-import { PlanningView } from '@/views/Planning';
-import { HistoryView } from '@/views/History';
-import { StatsView } from '@/views/Stats';
-import { SettingsView } from '@/views/Settings';
-import { DonateView } from '@/views/Donate';
 import { authStore } from 'stores';
-import { SignUpView } from '@/views/SignUp';
-import { ConfirmationView } from '@/views/Confirmation';
-import { RecoveryView } from '@/views/Recovery';
-import { CalengradeView } from '@/views/Calengrade';
-import { FacebookView } from '@/views/Facebook';
+const ReviewsView = () => import('@/views/Reviews/ReviewsView.vue');
+const PerformanceView = () => import('@/views/Performance/PerformanceView.vue');
+const PlanningView = () => import('@/views/Planning/PlanningView.vue');
+const HistoryView = () => import('@/views/History/HistoryView.vue');
+const StatsView = () => import('@/views/Stats/StatsView.vue');
+const SettingsView = () => import('@/views/Settings/SettingsView.vue');
+const DonateView = () => import('@/views/Donate/DonateView.vue');
+const SignUpView = () => import('@/views/SignUp/SignUpView.vue');
+const ConfirmationView = () =>
+  import('@/views/Confirmation/ConfirmationView.vue');
+const RecoveryView = () => import('@/views/Recovery/RecoveryView.vue');
+const CalengradeView = () => import('@/views/Calengrade/CalengradeView.vue');
+const FacebookView = () => import('@/views/Facebook/FacebookView.vue');
 
 const isJWT = (token: string) =>
   /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_.+/=]*$/.test(token);

--- a/apps/container/src/views/Reviews/ReviewsView.test.ts
+++ b/apps/container/src/views/Reviews/ReviewsView.test.ts
@@ -1,7 +1,7 @@
 import { render, screen } from '@/test-utils';
 import { ReviewsView } from '.';
 import { useRouter } from 'vue-router';
-import { subjectSearch, teacherSearch } from '@/mocks/reviews';
+import { subjectSearch } from '@/mocks/reviews';
 
 vi.mock('vue-router', async () => ({
   useRouter: vi.fn(),
@@ -47,27 +47,6 @@ describe('<ReviewsView />', () => {
       await screen.findByText(/Seus professores para avaliar/i),
     ).toBeInTheDocument();
   });
-  test.skip('render teacher search', async () => {
-    vi.mocked(useRouter).mockReturnValue({
-      useRouter: vi.fn(),
-      createRouter: vi.fn(() => ({
-        beforeEach: vi.fn(),
-      })),
-      replace: replaceMock,
-      currentRoute: {
-        value: {
-          query: {
-            q: teacherSearch.data[0].name,
-            teacherId: teacherSearch.data[0]._id,
-          },
-        },
-      },
-    } as unknown as ReturnType<typeof useRouter>);
-    render(ReviewsView);
-    expect(
-      await screen.findByText(/Provavelmente esse professor cobra presença/i),
-    ).toBeInTheDocument();
-  });
   test('render subject search', async () => {
     vi.mocked(useRouter).mockReturnValue({
       useRouter: vi.fn(),
@@ -88,8 +67,6 @@ describe('<ReviewsView />', () => {
     expect(
       await screen.findByText(subjectSearch.data[0].name),
     ).toBeInTheDocument();
-    expect(
-      await screen.findByText(/Nome do Professor/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/Nome do Professor/i)).toBeInTheDocument();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,7 +388,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/plugin-syntax-dynamic-import@^7.8.3":
+"@babel/plugin-syntax-dynamic-import@7.8.3", "@babel/plugin-syntax-dynamic-import@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
   integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==


### PR DESCRIPTION
## Descrição

Adiciona a estrategia de imports dinâmicos no router do vue

Evidencia (verificar numero de requests adicionais ao navegar por todas as páginas do next, requests sendo feitas para puxar o js isolado das páginas)

Antes:
![image](https://github.com/ufabc-next/ufabc-next-web/assets/58098722/ab68e0f8-a9e5-484b-9c33-ee7d26f049f5)
Depois:
![image](https://github.com/ufabc-next/ufabc-next-web/assets/58098722/6e4429e3-2044-4773-8a77-b363f12f9b43)


## Como testar esse PR

Acesse as páginas do Next e verifique que requisições estão sendo feitas para puxar o código das páginas

## Adicionou/atualizou testes automatizados?

- [ ] Sim
- [X] Não, porque: Feature não testavel por testes
- [ ] Preciso de ajuda para escrever testes