### PR TITLE
fix: approvation filter in subjects was inverted

### DIFF
--- a/apps/container/src/components/SubjectReview/SubjectReview.vue
+++ b/apps/container/src/components/SubjectReview/SubjectReview.vue
@@ -229,9 +229,9 @@ const shortedSpecifics = computed(() => {
   } else if (selectedOrder.value === 'samplesDecres') {
     sorted.sort((a, b) => b.count - a.count);
   } else if (selectedOrder.value === 'mostApproved') {
-    sorted.sort((a, b) => approveRating(a) - approveRating(b));
-  } else if (selectedOrder.value === 'leastApproved') {
     sorted.sort((a, b) => approveRating(b) - approveRating(a));
+  } else if (selectedOrder.value === 'leastApproved') {
+    sorted.sort((a, b) => approveRating(a) - approveRating(b));
   }
 
   return sorted;


### PR DESCRIPTION
Arruma filtro de ordenar por maior aprovação e vice-versa (estava mostrando invertido)
Antes:
![image](https://github.com/user-attachments/assets/44f752db-c7a4-4d4d-907c-f8356588ae34)


Depois:
![image](https://github.com/user-attachments/assets/b4fff81a-725c-43be-94ff-df16d5da737a)
