### PR TITLE
docs: add agent project guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-@/Users/renan/.codex/RTK.md
-
 # AGENTS.md
 
 ## Scope

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+@/Users/renan/.codex/RTK.md
+
+# AGENTS.md
+
+## Scope
+
+These instructions apply to the whole `ufabc-next-web` repository.
+
+This is a pnpm/Turborepo monorepo. The main app is `apps/container`, a Vue 3 SPA built with Vite. Shared API clients live in `packages/services`, shared TypeScript contracts live in `packages/types`, and shared lint rules live in `packages/eslint-config-custom`.
+
+## Commands
+
+- Run shell commands with `rtk`, as required by the included global instructions.
+- Use pnpm from the repository root. The expected toolchain is Node 20.19.x and pnpm 10.28.x.
+- Common checks:
+  - `pnpm lint`
+  - `pnpm test`
+  - `pnpm tsc`
+  - `pnpm build`
+- For app-only work, prefer package-scoped scripts when practical:
+  - `pnpm --filter ufabc-next-web-container lint`
+  - `pnpm --filter ufabc-next-web-container test`
+  - `pnpm --filter ufabc-next-web-container type-check`
+  - `pnpm --filter ufabc-next-web-container build`
+- For package-only work, use the package scripts that actually exist:
+  - `pnpm --filter @ufabc-next/services lint`
+  - `pnpm --filter @ufabc-next/services tsc`
+  - `pnpm --filter @ufabc-next/types lint`
+  - `pnpm --filter @ufabc-next/types tsc`
+- If you add or read new environment variables, update the relevant `turbo.json` task `env` list for `build`, `build:staging`, and/or `dev`. Code currently reads Vite-style variables such as `VITE_APP_ENV`, `VITE_APP_BASE_URL`, and `VITE_MIXPANEL_TOKEN`; do not copy stale `VUE_APP_*` names into new code.
+
+## Repository Patterns
+
+- Keep application code in English. User-facing product copy is mostly Portuguese and should stay natural for UFABC students.
+- Prefer existing project libraries before adding new dependencies: Vue 3, Vuetify 3, Element Plus, TanStack Vue Query, Pinia, vee-validate, zod, VueUse, dayjs, Highcharts/highcharts-vue, amCharts, `ics`, Mixpanel, `lodash.debounce`, Testing Library, Vitest, and MSW.
+- Use `@/` for imports inside `apps/container/src`.
+- Keep API calls out of Vue components. Add or adjust endpoint wrappers in `packages/services/src`, and add shared response/request types in `packages/types/src` when they are reused across the app. When adding new modules, update the matching barrel export in `packages/services/src/index.ts` or `packages/types/src/index.ts`.
+- Do not create frontend mock backends when the real backend owns the endpoint. Link the backend PR/API route and adapt the frontend to that contract.
+- Treat `apps/static` as static HTML/assets. Do not assume Vue components, composables, or Vuetify are available there.
+- Preserve Vite routing assumptions: local dev runs at port `3000`, production app assets are served under `/app`, and router history uses `import.meta.env.VITE_APP_BASE_URL`.
+- Route changes must preserve the existing auth conventions: route meta uses `confirmed`, `auth`, and `layout: 'include-sidebar'`; token auth can arrive through `?token=`; unauthenticated redirects intentionally differ between local dev and production.
+
+## Vue And TypeScript
+
+- Follow Vue 3 Composition API with `<script setup lang="ts">`.
+- Prefer TypeScript types for props and emits:
+  - `defineProps<Props>()`
+  - `withDefaults(defineProps<Props>(), defaults)` for optional props with defaults
+  - `defineEmits<{ close: []; update: [value: string] }>()` using named tuples
+  - `defineModel<T>()` or named `defineModel<T>('field')` for new two-way bindings
+- As a project convention, do not destructure props directly. Keep `const props = defineProps<...>()` and derive values with `computed` when needed.
+- Prefer `computed` for derived, read-only state. Use `ref` for mutable local state, and `shallowRef` for large or external objects when deep reactivity is unnecessary.
+- Keep route state idiomatic. Use `useRoute` and `useRouter` from `vue-router` instead of reading route params/query from `window.location`.
+- When state depends on route query or another narrow source, name it specifically. For example, prefer names like `componentSelectedByQueryUrl` over generic names like `selectedComponent`.
+- Extract reusable cross-component behavior into composables under `apps/container/src/utils/composables` when logic spans components, especially theme/localStorage interactions or repeated formatting. Name composables as `useXxx`; when they return derived read-only state, prefer `computed`/readonly values over mutable refs.
+- Keep watchers narrow and intentional. Prefer `computed` when a value can be derived without side effects. Async watchers/effects must clean up cancellable requests, timers, and subscriptions with Vue watcher cleanup APIs.
+- Use Vue built-ins intentionally: `<Transition>`/`<TransitionGroup>` for Vue-managed animation, `<Teleport>` for out-of-tree UI when Vuetify is not handling it, `<Suspense>` only for async setup/top-level await, `<KeepAlive>` only when preserving component state is intentional, and `v-memo`/`v-once` only for measured render pressure.
+- Avoid leaving temporary comments, debug logs, or TODOs unless they describe a real follow-up that cannot be solved in the current change.
+
+## Data Fetching And State
+
+- Use TanStack Vue Query for server state and cacheable API reads. Keep query keys stable and specific.
+- Use Pinia for authenticated user/session state and app state that must be shared across views.
+- Keep `packages/services` focused on request wrappers and API response typing. Form validation and user-facing error handling usually belong in the view/form layer with `vee-validate`, zod schemas, and local UI state.
+- Tests should use `apps/container/src/test-utils.ts` so Vuetify, Element Plus, and Vue Query are installed consistently.
+- `test-utils.ts` does not install Pinia or router globally. Auth/store-heavy tests should create Pinia state intentionally, and route-heavy tests should install or mock `vue-router` intentionally.
+- In tests, prefer MSW handlers over mocking implementation details of service functions when testing UI behavior around requests.
+- Handle loading, empty, and error states explicitly for user-facing flows.
+- Be careful with chained API calls. Recent reviews called out performance degradation from sequential parser calls; cache or reuse data when the response is common and stable.
+
+## UI, Copy, And Accessibility
+
+- Use Vuetify components and project components such as `PaperCard`, `FeedbackAlert`, `CenteredLoading`, and existing cards before creating one-off UI.
+- Keep visual changes easy to review. For UI PRs, include screenshots or videos and explain the tested state, especially logged-in versus logged-out flows.
+- Copy should make the user action clear. Recent reviews favored explicit button labels and explanatory notices when login behavior changed.
+- Avoid ambiguous control labels. Filter and toggle text should describe the resulting behavior, such as `Ocultar EAD` or `Incluir EAD`, instead of a label that can mean the opposite.
+- Important auth/login behavior changes should not rely only on a tooltip. Prefer a short visible notice or notification pattern, and keep the primary button label explicit.
+- Avoid cluttering screens with long inline explanations. If text makes the layout noisy, prefer a notification/alert pattern or a concise helper message.
+- Use icons from the existing icon stack (`mdi-*`) inside Vuetify components.
+- Preserve responsive behavior. Check desktop and mobile layouts when changing cards, tables, dialogs, filters, or dropdown-heavy flows.
+- Images need useful `alt` text. Icon-only buttons need an accessible label when the visible label is absent.
+
+## Tests And Verification
+
+- Add or update tests for behavior that can regress, not only render snapshots. Reviews explicitly asked for tests that preserve component behavior through future changes.
+- Use Testing Library queries that match user-visible behavior: roles, labels, text, placeholders, and interactions through `userEvent`.
+- Use `waitFor` or `findBy*` for async UI driven by Vue Query, router updates, dialogs, or MSW responses.
+- For changes touching auth, login, route guards, signup, recovery, or backend contracts, test both success and failure paths when practical.
+- For features that depend on an external API or backend session, do not mark the work ready on local UI checks alone. Verify the integrated frontend-to-API path or document exactly who/what is blocking that validation.
+
+## PR Expectations
+
+- Fill the PR template sections: description, related tickets, and how to test.
+- Include concrete evidence for visual or behavioral changes. The team often asks for screenshots, videos, or a short note confirming the exact scenario tested.
+- Evidence should reflect the latest pushed state, not an earlier implementation. Name the scenario tested and call out dev-data caveats such as unavailable mock groups.
+- Mention whether the test covered logged-in and logged-out states when the feature behaves differently by auth state.
+- If a change affects backend/API behavior, point to the related backend PR or API change when one exists.
+- Keep changes focused. If the core fix belongs in `packages/services`, put it there and keep view changes limited to adapting to the fixed contract.
+- Before handoff, remove temporary review artifacts: debug comments, leftover console output, dead branches, unused imports, POC/test files, generated artifacts, unused dependencies/types, sample templates, and unjustified `eslint-disable`s.


### PR DESCRIPTION
## Descrição

Cria um `AGENTS.md` na raiz do repositório para orientar agentes que forem trabalhar no `ufabc-next-web`.

O arquivo consolida três fontes de contexto:

1. padrões já presentes no código atual do projeto;
2. comentários humanos dos últimos 50 PRs, ignorando Copilot, Renovate e outros bots/agents;
3. orientações da skill Vue usada para Vue 3 Composition API com `<script setup lang="ts">`.

## O que foi documentado

- Estrutura do monorepo: `apps/container` como SPA Vue 3/Vite, `packages/services` para wrappers de API, `packages/types` para contratos compartilhados e `packages/eslint-config-custom` para lint.
- Comandos esperados com pnpm/Turborepo, incluindo comandos globais e comandos filtrados para app, services e types.
- Cuidados com variáveis Vite no `turbo.json`, especialmente `VITE_APP_ENV`, `VITE_APP_BASE_URL` e `VITE_MIXPANEL_TOKEN`, evitando copiar nomes antigos `VUE_APP_*`.
- Padrões de Vue/TypeScript: Composition API, `<script setup lang="ts">`, props/emits tipados, `defineModel`, `computed` para estado derivado, `ref`/`shallowRef`, composables `useXxx`, uso de `useRoute`/`useRouter` e watchers com cleanup quando necessário.
- Padrões de dados e estado: TanStack Vue Query para server state, Pinia para auth/app state, MSW em testes de UI, e regra de manter contrato de API em `packages/services`/`packages/types`.
- Convenções de UI/copy/acessibilidade: Vuetify e componentes existentes primeiro, labels explícitos, avisos visíveis para mudanças importantes de auth/login, `alt` em imagens e labels acessíveis em botões icon-only.
- Expectativas de teste e PR: testes comportamentais, evidência visual atualizada, cenários logado/não logado quando relevante, validação integrada com API quando a feature depende de backend, e cleanup antes do handoff.

## Por que

O repositório já tinha padrões importantes espalhados entre código, README, scripts, configuração e histórico de review. Isso fazia agentes dependerem de inferência a cada alteração.

O `AGENTS.md` reduz esse custo e torna explícitas as expectativas que o time reforça nos PRs, principalmente:

- pedir evidência visual ou funcional quando a mudança altera UI/comportamento;
- preservar idiomática Vue em rotas, composables, estado derivado e bindings;
- manter wrappers e contratos de API nos pacotes corretos;
- evitar labels ambíguos e copy que dependa só de tooltip;
- adicionar testes que protejam comportamento, não só renderização;
- separar validação local de validação integrada quando há dependência de backend.

## Como testar esse PR

Mudança apenas documental.

Validação feita:

- leitura final do `AGENTS.md` criado;
- revisão do diff staged antes do commit;
- revisão por 3 subagents com focos separados: aderência ao código do repo, padrões dos PRs recentes e orientação Vue/Composition API.

Não rodei `pnpm test`, `pnpm lint` ou `pnpm build` porque não há alteração de código executável.
