### PR TITLE
fix: add default visualization

### DIFF
--- a/apps/container/src/views/WhatsappGroups/WhatsappGroupsView.vue
+++ b/apps/container/src/views/WhatsappGroups/WhatsappGroupsView.vue
@@ -349,6 +349,7 @@ import { capitalizeName } from '@/utils/capitalizeName';
 
 type SearchType = 'ra' | 'component' | 'course';
 const MIN_RA_LENGTH = 8;
+const DEFAULT_COURSE_NAME = 'Bacharelado em Ciências e Tecnologia';
 
 const showOverlay = ref(false);
 const defaultSeason = getCurrentAcademicSeason();
@@ -436,7 +437,30 @@ const debouncedRaSearch = useDebounceFn((raValue: number) => {
   }
 }, 500);
 
-const selectSearchType = (type: SearchType) => {
+const applyDefaultCourseSelection = () => {
+  if (!coursesList.value.length) {
+    return;
+  }
+
+  if (searchCourseQuery.value !== null && String(searchCourseQuery.value).trim()) {
+    return;
+  }
+
+  const normalizedDefault = normalizeText(DEFAULT_COURSE_NAME);
+  const defaultCourse = coursesList.value.find(
+    (course: SearchCourseItem) =>
+      normalizeText(course.name) === normalizedDefault,
+  );
+
+  if (!defaultCourse) {
+    return;
+  }
+
+  searchCourseQuery.value = defaultCourse.id;
+};
+
+const selectSearchType = (type: SearchType | null) => {
+  const normalizedType = type ?? 'course';
   if (!isUserLoggedIn.value) {
     searchRaQuery.value = null;
   }
@@ -444,13 +468,17 @@ const selectSearchType = (type: SearchType) => {
   searchComponentQuery.value = '';
   searchCourseQuery.value = null;
   searchCourseFilterQuery.value = '';
-  selectedSearchType.value = type;
+  selectedSearchType.value = normalizedType;
   shouldFetchGroupsByRa.value = false;
   shouldFetchComponents.value = false;
   shouldFetchGroupsByCourse.value = false;
   queryResultsPage.value = 1;
 
-  if (type === 'ra' && isRaValid.value && searchRaQuery.value) {
+  if (normalizedType === 'course') {
+    applyDefaultCourseSelection();
+  }
+
+  if (normalizedType === 'ra' && isRaValid.value && searchRaQuery.value) {
     debouncedRaSearch(searchRaQuery.value);
   }
 };
@@ -515,6 +543,17 @@ watch(searchCourseQuery, (newCourseId) => {
 watch(searchCourseFilterQuery, () => {
   if (selectedSearchType.value === 'course') {
     queryResultsPage.value = 1;
+  }
+});
+
+watch(selectedSearchType, (newType) => {
+  if (!newType) {
+    selectSearchType('course');
+    return;
+  }
+
+  if (newType === 'course') {
+    applyDefaultCourseSelection();
   }
 });
 
@@ -650,6 +689,12 @@ const coursesList = computed(() => {
     .sort((a: SearchCourseItem, b: SearchCourseItem) =>
       a.name.localeCompare(b.name),
     );
+});
+
+watch(coursesList, () => {
+  if (selectedSearchType.value === 'course') {
+    applyDefaultCourseSelection();
+  }
 });
 
 const normalizeCourseCode = (code: string | null | undefined) =>
@@ -846,6 +891,19 @@ const currentSuccess = computed(
 
 const currentError = computed(
   () => searchConfig.value[selectedSearchType.value]?.error || false,
+);
+
+watch(
+  [selectedSearchType, currentSuccess, currentLoading, currentGroups],
+  ([type, success, loading, groups]) => {
+    if (type !== 'ra' || loading || !success) {
+      return;
+    }
+
+    if (groups.length === 0) {
+      selectSearchType('course');
+    }
+  },
 );
 
 const openWhatsappGroup = (url: string) => {


### PR DESCRIPTION
## Descrição

Adicionei um fallback automatico para trocar da busca por RA para a busca por curso quando a consulta de RA termina com sucesso e nao retorna grupos, garantindo que a tela passe para a visao de curso com o curso default “Bacharelado em Ciencias e Tecnologia” ja selecionado assim que os cursos forem carregados.


## Tickets relacionados

## Como testar esse PR
