### PR TITLE
feat: support both @aluno.ufabc.edu.br and @ufabc.edu.br emails

### DIFF
--- a/apps/container/src/utils/composables/aliasInitials.ts
+++ b/apps/container/src/utils/composables/aliasInitials.ts
@@ -11,7 +11,7 @@ export function useAliasInitials() {
 
   const alias = ref('');
 
-  const userLogin = authStore.user?.email?.replace('@aluno.ufabc.edu.br', '').toUpperCase();
+  const userLogin = authStore.user?.email?.replace(/@(aluno\.)?ufabc\.edu\.br$/, '').toUpperCase();
 
   if (userLogin) {
     const userSplited = userLogin.split('.');

--- a/apps/container/src/utils/composables/cleanUsername.ts
+++ b/apps/container/src/utils/composables/cleanUsername.ts
@@ -6,7 +6,7 @@ export function useCleanUsername() {
   const authStore = useAuthStore();
 
   const userCleanUsername = computed(
-    () => authStore.user?.email?.replace('@aluno.ufabc.edu.br', '') || '',
+    () => authStore.user?.email?.replace(/@(aluno\.)?ufabc\.edu\.br$/, '') || '',
   );
   return userCleanUsername;
 }

--- a/apps/container/src/views/Recovery/RecoveryView.vue
+++ b/apps/container/src/views/Recovery/RecoveryView.vue
@@ -14,6 +14,14 @@ const router = useRouter();
 
 const redirectToHome = () => (window.location.pathname = '/');
 
+const outlookDomain = computed(() => {
+  const userEmail = email.value.value;
+  if (userEmail?.includes('@aluno.ufabc.edu.br')) {
+    return 'aluno.ufabc.edu.br';
+  }
+  return 'ufabc.edu.br';
+});
+
 const validationSchema = toTypedSchema(recoverySchema as any);
 
 const { handleSubmit, meta } = useForm({
@@ -219,7 +227,7 @@ const onSubmit = handleSubmit(({ email }) =>
           </h1>
           <p class="mb-4">
             Você recebeu um email para recuperar sua conta,
-            <a href="https://www.outlook.com/aluno.ufabc.edu.br" target="_blank"
+            <a :href="`https://www.outlook.com/${outlookDomain}`" target="_blank"
               >clique aqui</a
             >
             para acessar seu email institucional.

--- a/apps/container/src/views/Recovery/recoveryValidationSchema.ts
+++ b/apps/container/src/views/Recovery/recoveryValidationSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const UFABC_EMAIL_REGEX = /^[A-Za-z0-9._%+-]+@aluno\.ufabc\.edu\.br$/;
+const UFABC_EMAIL_REGEX = /^[A-Za-z0-9._%+-]+@(aluno\.)?ufabc\.edu\.br$/;
 
 export const recoverySchema = z.object({
   email: z
@@ -11,6 +11,6 @@ export const recoverySchema = z.object({
     .email('Formato de email inválido')
     .refine(
       (email) => UFABC_EMAIL_REGEX.test(email),
-      'Digite um email UFABC válido (domínio @aluno.ufabc.edu.br)',
+      'Digite um email UFABC válido (domínios @aluno.ufabc.edu.br ou @ufabc.edu.br)',
     ),
 });

--- a/apps/container/src/views/Settings/SettingsView.vue
+++ b/apps/container/src/views/Settings/SettingsView.vue
@@ -150,7 +150,7 @@ const {
 });
 
 const userLogin = computed(() => {
-  return user.value?.email?.replace('@aluno.ufabc.edu.br', '');
+  return user.value?.email?.replace(/@(aluno\.)?ufabc\.edu\.br$/, '');
 });
 
 const addGoogleAccount = computed(() => {

--- a/apps/container/src/views/SignUp/SignUpView.vue
+++ b/apps/container/src/views/SignUp/SignUpView.vue
@@ -371,7 +371,7 @@ const { mutate: mutateSignUp, isPending: isPendingSubmit } = useMutation({
   onError: (error: AxiosError<RequestError>) => {
     const message =
       error.status === 500
-        ? 'Seu login falhou, tente novamente com o email institucional @aluno.ufabc.edu.br'
+        ? 'Seu login falhou, tente novamente com o email institucional (@aluno.ufabc.edu.br ou @ufabc.edu.br)'
         : error.response?.data.message;
     ElMessage({
       message,
@@ -468,7 +468,7 @@ watch(
     if (user.value?.ra && user.value?.email) {
       step.value = 3;
       setValues({
-        email: user.value.email.replace('@aluno.ufabc.edu.br', ''),
+        email: user.value.email.replace(/@(aluno\.)?ufabc\.edu\.br$/, ''),
         ra: {
           ra: user.value.ra.toString(),
           confirm: user.value.ra.toString(),

--- a/apps/static/index.html
+++ b/apps/static/index.html
@@ -489,7 +489,7 @@
                       id="googleLoginBtn"
                       data-toggle="tooltip"
                       data-placement="right"
-                      title="Use seu e-mail institucional (@aluno.ufabc.edu.br) para acesso imediato, sem precisar confirmar a conta."
+                      title="Use seu e-mail institucional (@aluno.ufabc.edu.br ou @ufabc.edu.br) para acesso imediato, sem precisar confirmar a conta."
                     >
                       <div class="google-button-icon-container">
                         <span class="google-button-icon-wrapper">


### PR DESCRIPTION
## Summary

Updates all frontend hardcoded references from `@aluno.ufabc.edu.br` only to accept both `@aluno.ufabc.edu.br` and `@ufabc.edu.br`.

## Changes

- `recoveryValidationSchema`: regex now accepts both domains
- `cleanUsername`, `aliasInitials`: domain-agnostic email stripping
- `SettingsView`, `SignUpView`: domain-agnostic display name extraction
- `SignUpView`: error message mentions both domains
- `RecoveryView`: Outlook link dynamically switches by domain
- `index.html`: tooltip updated

## Related PR

**Must be merged together with:** https://github.com/ufabc-next/ufabc-next-backend/pull/241

## Testing

Run signup, recovery, and settings flows with both email domains.