### PR TITLE
feat: port backend features from ufabc-next-backend

### DIFF
--- a/apps/core/src/connectors/ai-proxy.ts
+++ b/apps/core/src/connectors/ai-proxy.ts
@@ -1,3 +1,4 @@
+import { ComponentMetadataDocument } from '@/models/ComponentMetadata.js';
 import { BaseRequester } from './base-requester.js';
 
 type Files = {
@@ -27,6 +28,56 @@ export class AIProxyConnector extends BaseRequester {
             pdfName: file.name,
           })),
         },
+      },
+    });
+    return response;
+  }
+
+  async requestNaturalResponse(componentData: ComponentMetadataDocument, userMessage: string) {
+    const headers = new Headers();
+
+    headers.set('x-service-id', 'whatsapp');
+
+    const toTitleCase = (s?: string) =>
+      (s || '')
+        .toLowerCase()
+        .split(' ')
+        .filter(Boolean)
+        .map((w) => w[0].toUpperCase() + w.slice(1))
+        .join(' ');
+
+    const nome_disciplina = (
+      componentData?.metadata?.component_data?.name ?? ''
+    ).toString().toUpperCase();
+    const codigo_turma = componentData?.metadata?.component_code ?? '';
+    const professor = toTitleCase(
+      componentData?.metadata?.component_data?.teachers?.[0]?.name ?? ''
+    );
+
+    const cronogramaArr = Array.isArray(componentData?.cronograma)
+      ? componentData.cronograma
+      : [];
+    const cronograma_str = cronogramaArr
+      .map((a) => `- ${a.data}: ${a.aula}`)
+      .join('\n');
+
+    const ementa = componentData.planejamento?.ementa ?? 'Não informada.';
+    const metodologia = componentData.planejamento?.metodologia ?? 'Não informada.';
+    const avaliacao = componentData.planejamento?.avaliacao ?? 'Não informada.';
+
+    const horarios_list =
+      componentData?.metadata?.component_data?.timetable ?? [];
+    const horarios_str = horarios_list
+      .map((h) => `- ${h?.unparsed ?? ''}`)
+      .join('\n');
+
+    const basePrompt = `## Contexto:\nVocê é um assistente virtual especializado em responder dúvidas de alunos da Universidade Federal do ABC (UFABC).\nVocê está prestando suporte específico para a disciplina: **${nome_disciplina} (${codigo_turma})**.\nO professor responsável é: ${professor}.\n\nUse estritamente as informações oficiais do Plano de Ensino fornecidas abaixo para responder o aluno.\n\n## Informações Oficiais da Disciplina:\n\n### 1. Horários e Salas:\n${horarios_str}\n\n### 2. Ementa da Disciplina:\n${ementa}\n\n### 3. Metodologia de Ensino:\n${metodologia}\n\n### 4. Critério de Avaliação:\n${avaliacao}\n\n### 5. Cronograma de Aulas e Datas Importantes:\n${cronograma_str}\n\n## Sua tarefa:\n- Leia a mensagem recebida do aluno e identifique o que está sendo perguntado.\n- Responda de maneira assertiva, amigável e direta baseando-se estritamente nos dados acima.\n- Se a pergunta for sobre uma data específica (como uma prova ou feriado), consulte a seção de Cronograma.\n- Se a pergunta for sobre salas, horários ou formas de avaliação, consulte as seções respectivas.\n- Caso o aluno pergunte algo que NÃO está neste documento, informe educadamente que não possui essa informação e sugira que ele verifique no Moodle, SIGAA ou diretamente com o professor ${professor}.\n\n## Instruções de estilo:\n- Mantenha um tom acolhedor, jovem e prestativo (adequado para WhatsApp).\n- Use quebras de linha e emojis moderadamente para tornar a leitura escaneável no celular.\n- Responda sempre em Português.\n\n## Mensagem recebida do aluno:\n"${userMessage}"\n`;
+
+    const response = await this.request<unknown[]>('/', {
+      method: 'POST',
+      headers: headers,
+      body: {
+        promptData: basePrompt
       },
     });
     return response;

--- a/apps/core/src/controllers/authentication-controller.ts
+++ b/apps/core/src/controllers/authentication-controller.ts
@@ -25,6 +25,12 @@ export const authenticationController: FastifyPluginAsyncZod = async (app) => {
     handler: async (request, reply) => {
       const { component, token } = request.body;
 
+      request.log.debug({ component, path: request.url, globalTraceId: request.id }, 'Received WhatsApp auth token validation request');
+
+      if (!token) {
+        return reply.badRequest('Token is required');
+      }
+
       let decryptedPayload: string;
       try {
         const secret = app.config.WHATSAPP_AUTH_SECRET;
@@ -68,7 +74,7 @@ export const authenticationController: FastifyPluginAsyncZod = async (app) => {
 
         decryptedPayload = payload.data;
       } catch (error) {
-        request.log.warn({ error }, 'Failed to decrypt WhatsApp auth token');
+        request.log.warn({ error, globalTraceId: request.id }, 'Failed to decrypt WhatsApp auth token');
         return reply.unauthorized('Invalid or expired token');
       }
 
@@ -79,6 +85,8 @@ export const authenticationController: FastifyPluginAsyncZod = async (app) => {
 
       const ra = decryptedPayload.slice(0, separatorIndex);
       const email = decryptedPayload.slice(separatorIndex + 1);
+
+      request.log.debug({ ra, email, path: request.url, globalTraceId: request.id }, 'Decrypted WhatsApp auth token payload');
 
       if (!ra || !email) {
         return reply.badRequest('Invalid token payload');
@@ -112,7 +120,7 @@ export const authenticationController: FastifyPluginAsyncZod = async (app) => {
       });
 
       request.log.info(
-        { userId: user._id, ra: user.ra },
+        { userId: user._id, ra: user.ra, path: request.url, globalTraceId: request.id },
         'WhatsApp auth token validated successfully'
       );
 

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -276,7 +276,7 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
   app.route({
     handler: async (request, reply) => {
-      const config = requester.server.config;
+      const { config } = request.server;
       const aiConnector = new AIProxyConnector(config.NEXT_AGENT_URL, 'whatsapp');
 
       const { season, componentId } = request.query;

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -1,42 +1,30 @@
-import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
-
 import { currentQuad } from '@next/utils';
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
+import { AIProxyConnector } from '@/connectors/ai-proxy.js';
 import { MoodleConnector } from '@/connectors/moodle.js';
 import { JOB_NAMES } from '@/constants.js';
 import { jwtVerifyHook } from '@/hooks/jwt-verify.js';
 import { moodleSession } from '@/hooks/moodle-session.js';
 import { ComponentModel } from '@/models/Component.js';
 import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
-import { AIProxyConnector } from '@/connectors/ai-proxy.js';
-import {
+import type {
   ListComponent,
-  listComponentsSchema,
   PopulatedComponent,
 } from '@/schemas/v2/components.js';
+import { listComponentsSchema } from '@/schemas/v2/components.js';
 import { getComponentArchives } from '@/services/components-service.js';
 
 const moodleConnector = new MoodleConnector();
 
 const componentsController: FastifyPluginAsyncZod = async (app) => {
   app.route({
-    method: 'POST',
-    url: '/components/archives',
-    preHandler: [moodleSession],
-    schema: {
-      response: {
-        202: z.object({
-          status: z.string(),
-        }),
-      },
-      headers: z.object({
-        'session-id': z.string(),
-        'sess-key': z.string(),
-      }),
-    },
     handler: async (request, reply) => {
-      const session = request.requestContext.get('moodleSession')! as { sessionId: string; sessKey: string };
+      const session = request.requestContext.get('moodleSession')! as {
+        sessionId: string;
+        sessKey: string;
+      };
       const hasLock = await request.acquireLock(session.sessionId, '24h');
 
       if (!hasLock) {
@@ -74,22 +62,28 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         return reply.internalServerError('Error getting archives');
       }
     },
-  });
-
-  app.route({
-    method: 'GET',
-    url: '/components/archives',
+    method: 'POST',
     preHandler: [moodleSession],
     schema: {
+      headers: z.object({
+        'session-id': z.string(),
+        'sess-key': z.string(),
+      }),
       response: {
-        200: z.object({
+        202: z.object({
           status: z.string(),
-          data: z.any().array(),
         }),
       },
     },
+    url: '/components/archives',
+  });
+
+  app.route({
     handler: async (request, reply) => {
-      const session = request.requestContext.get('moodleSession')! as { sessionId: string; sessKey: string };
+      const session = request.requestContext.get('moodleSession')! as {
+        sessionId: string;
+        sessKey: string;
+      };
       const components = await moodleConnector.getComponents(
         session.sessionId,
         session.sessKey
@@ -99,27 +93,9 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         data: components,
       });
     },
-  });
-
-  app.route({
     method: 'GET',
-    url: '/components/archives/uploads',
-    handler: async (_request, reply) => {
-      const uploads = await app.aws.s3.list(app.config.AWS_BUCKET);
-      return reply.status(200).send({
-        status: 'success',
-        data: uploads,
-      });
-    },
-  });
-
-  app.route({
-    method: 'GET',
-    url: '/components/pending-group-url',
+    preHandler: [moodleSession],
     schema: {
-      querystring: z.object({
-        season: z.string(),
-      }),
       response: {
         200: z.object({
           status: z.string(),
@@ -127,6 +103,22 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         }),
       },
     },
+    url: '/components/archives',
+  });
+
+  app.route({
+    handler: async (_request, reply) => {
+      const uploads = await app.aws.s3.list(app.config.AWS_BUCKET);
+      return reply.status(200).send({
+        status: 'success',
+        data: uploads,
+      });
+    },
+    method: 'GET',
+    url: '/components/archives/uploads',
+  });
+
+  app.route({
     handler: async (request, reply) => {
       const { season } = request.query;
 
@@ -207,20 +199,22 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         data: requested,
       });
     },
+    method: 'GET',
+    schema: {
+      querystring: z.object({
+        season: z.string(),
+      }),
+      response: {
+        200: z.object({
+          status: z.string(),
+          data: z.any().array(),
+        }),
+      },
+    },
+    url: '/components/pending-group-url',
   });
 
   app.route({
-    method: 'GET',
-    url: '/components',
-    preHandler: [jwtVerifyHook],
-    schema: {
-      querystring: z.object({
-        season: z.string().default(currentQuad()),
-      }),
-      response: {
-        200: listComponentsSchema,
-      },
-    },
     handler: async (request, reply) => {
       const { season } = request.query;
       const cacheKey = `list:components:${season}`;
@@ -267,29 +261,23 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
       return reply.status(200).send(mappedComponents);
     },
+    method: 'GET',
+    preHandler: [jwtVerifyHook],
+    schema: {
+      querystring: z.object({
+        season: z.string().default(currentQuad()),
+      }),
+      response: {
+        200: listComponentsSchema,
+      },
+    },
+    url: '/components',
   });
 
   app.route({
-    method: 'POST',
-    url: '/components/metadata',
-    schema: {
-      querystring: z.object({
-        season: z.string().default('2026:2'),
-        componentId: z.string()
-      }),
-      body: z.object({
-        userMessage: z.string(),
-      }),
-      response: {
-        200: z.object({
-          status: z.string(),
-          data: z.any().optional(),
-        }),
-      },
-    },
     handler: async (request, reply) => {
-      const baseUrl = process.env.NEXT_AGENT_URL;
-      const aiConnector = new AIProxyConnector(baseUrl, 'whatsapp');
+      const config = requester.server.config;
+      const aiConnector = new AIProxyConnector(config.NEXT_AGENT_URL, 'whatsapp');
 
       const { season, componentId } = request.query;
 
@@ -304,13 +292,33 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
       const { userMessage } = request.body as { userMessage: string };
 
-      const response = await aiConnector.requestNaturalResponse(component, userMessage);
+      const response = await aiConnector.requestNaturalResponse(
+        component,
+        userMessage
+      );
 
       return reply.status(200).send({
         status: 'success',
         data: response,
       });
     },
+    method: 'POST',
+    schema: {
+      body: z.object({
+        userMessage: z.string(),
+      }),
+      querystring: z.object({
+        season: z.string().default('2026:2'),
+        componentId: z.string(),
+      }),
+      response: {
+        200: z.object({
+          status: z.string(),
+          data: z.any().optional(),
+        }),
+      },
+    },
+    url: '/components/metadata',
   });
 };
 

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -8,6 +8,8 @@ import { JOB_NAMES } from '@/constants.js';
 import { jwtVerifyHook } from '@/hooks/jwt-verify.js';
 import { moodleSession } from '@/hooks/moodle-session.js';
 import { ComponentModel } from '@/models/Component.js';
+import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
+import { AIProxyConnector } from '@/connectors/ai-proxy.js';
 import {
   ListComponent,
   listComponentsSchema,
@@ -264,6 +266,50 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       );
 
       return reply.status(200).send(mappedComponents);
+    },
+  });
+
+  app.route({
+    method: 'POST',
+    url: '/components/metadata',
+    schema: {
+      querystring: z.object({
+        season: z.string().default('2026:2'),
+        componentId: z.string()
+      }),
+      body: z.object({
+        userMessage: z.string(),
+      }),
+      response: {
+        200: z.object({
+          status: z.string(),
+          data: z.any().optional(),
+        }),
+      },
+    },
+    handler: async (request, reply) => {
+      const baseUrl = process.env.NEXT_AGENT_URL;
+      const aiConnector = new AIProxyConnector(baseUrl, 'whatsapp');
+
+      const { season, componentId } = request.query;
+
+      const component = await ComponentMetadataModel.findOne({
+        'metadata.component_code': componentId,
+        'metadata.component_data.season': season,
+      });
+
+      if (!component) {
+        return reply.notFound('Component not found');
+      }
+
+      const { userMessage } = request.body as { userMessage: string };
+
+      const response = await aiConnector.requestNaturalResponse(component, userMessage);
+
+      return reply.status(200).send({
+        status: 'success',
+        data: response,
+      });
     },
   });
 };

--- a/apps/core/src/controllers/proxy-controller.ts
+++ b/apps/core/src/controllers/proxy-controller.ts
@@ -17,11 +17,28 @@ export const proxyController: FastifyPluginAsyncZod = async (app) => {
       }),
       response: {
         202: z.object({ message: z.string() }),
-        502: z.object({ message: z.string() }),
+        429: z.object({ message: z.string() }),
       },
     },
     preHandler: [permissionVerifyHook(ALLOWED_ANNOUNCEMENT_PERMISSIONS)],
+    onError: async (request, _, error) => {
+      const lockKey = `announcement:${request.user._id}`;
+      await request.releaseLock(lockKey);
+      request.log.error(
+        { error, userId: request.user._id },
+        'Failed to send announcement'
+      );
+    },
     handler: async (request, reply) => {
+      const lockKey = `announcement:${request.user._id}`;
+      const hasLock = await request.acquireLock(lockKey, '24h');
+
+      if (!hasLock) {
+        return reply.status(429).send({
+          message: 'You can only send one announcement per day',
+        });
+      }
+
       const communications = new CommunicationsConnector(
         app.config.COMMUNICATIONS_API_URL,
         request.id

--- a/apps/core/src/models/ComponentMetadata.ts
+++ b/apps/core/src/models/ComponentMetadata.ts
@@ -1,0 +1,87 @@
+import { type InferSchemaType, Schema, model } from 'mongoose';
+
+const disciplinasMetadataSchema = new Schema(
+  {
+    planejamento: {
+      ementa: { type: String, required: true },
+      objetivos: { type: String, required: true },
+      metodologia: { type: String, required: true },
+      avaliacao: { type: String, required: true },
+    },
+    cronograma: [
+      {
+        aula: { type: String, required: true },
+        data: { type: String, required: true },
+        _id: false,
+      },
+    ],
+    metadata: {
+      source_file: { type: String, required: true },
+      processed_at: { type: String, required: true },
+      disciplina_id: { type: Number, required: true },
+      component_code: { type: String, required: true },
+      component_data: {
+        componentKey: { type: String, required: true },
+        subjectKey: { type: String, required: true },
+        name: { type: String, required: true },
+        credits: { type: Number, required: true },
+        ufComponentId: { type: Number, required: true },
+        alternateUfabcComponentId: { type: String, required: false },
+        ufComponentCode: { type: String, required: true },
+        campus: { type: String, required: true },
+        shift: { type: String, required: true },
+        vacancies: { type: Number, required: true },
+        componentClass: { type: String, required: true },
+        season: { type: String, required: true },
+        ufClassroomCode: { type: String, required: true },
+        tpi: {
+          theory: { type: Number, required: true },
+          practice: { type: Number, required: true },
+          individual: { type: Number, required: true },
+          _id: false,
+        },
+        timetable: [
+          {
+            dayOfTheWeek: { type: String, required: true },
+            startTime: { type: String, required: true },
+            endTime: { type: String, required: true },
+            periodicity: { type: String, required: false },
+            classroomCode: { type: String, required: true },
+            scheduleType: { type: String, required: true },
+            frequency: { type: String, required: true },
+            unparsed: { type: String, required: true },
+            _id: false,
+          },
+        ],
+        courses: [
+          {
+            category: { type: String, required: true },
+            UFCourseId: { type: Number, required: true },
+            _id: false,
+          },
+        ],
+        teachers: [
+          {
+            name: { type: String, required: true },
+            role: { type: String, required: true },
+            isSecondary: { type: Boolean, required: true },
+            _id: false,
+          },
+        ],
+        _id: false,
+      },
+      _id: false,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+
+disciplinasMetadataSchema.index({ 'metadata.component_code': 'asc' });
+
+export type ComponentMetadata = InferSchemaType<typeof disciplinasMetadataSchema>;
+export type ComponentMetadataDocument = ReturnType<(typeof ComponentMetadataModel)['hydrate']>;
+
+export const ComponentMetadataModel = model('disciplinas_metadata', disciplinasMetadataSchema, 'disciplinas_metadata');

--- a/apps/core/src/routes/comments/index.ts
+++ b/apps/core/src/routes/comments/index.ts
@@ -57,6 +57,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
 
   app.post('/', { schema: createCommentSchema }, async (request, reply) => {
     const { enrollment: enrollmentId, comment, type } = request.body;
+    const user = request.user;
 
     if (!comment || !enrollmentId || !type) {
       return reply.badRequest('Body must have all obligatory fields');
@@ -66,6 +67,14 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
 
     if (!enrollment) {
       return reply.notFound('Enrollment not found');
+    }
+
+    if (Number(user.ra) !== Number(enrollment.ra)) {
+      request.log.warn(
+        { userRa: user.ra, commentRa: enrollment.ra },
+        'Unauthorized comment creation attempt'
+      );
+      return reply.forbidden();
     }
 
     if (!enrollment.subject || !enrollment.ra) {
@@ -97,6 +106,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
     { schema: updateCommentSchema },
     async (request, reply) => {
       const { commentId } = request.params;
+      const user = request.user;
 
       if (!commentId) {
         request.log.warn({ params: request.params }, 'Missing commentId');
@@ -108,6 +118,14 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
       if (!comment) {
         request.log.warn(comment, 'Comment missing');
         return reply.notFound('Comment not found');
+      }
+
+      if (Number(user.ra) !== Number(comment.ra)) {
+        request.log.warn(
+          { userRa: user.ra, commentRa: comment.ra },
+          'Unauthorized comment update attempt'
+        );
+        return reply.forbidden();
       }
 
       comment.comment = request.body.comment;
@@ -123,6 +141,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
     { schema: deleteCommentSchema },
     async (request, reply) => {
       const { commentId } = request.params;
+      const user = request.user;
 
       if (!commentId) {
         request.log.warn({ params: request.params }, 'Missing commentId');
@@ -134,6 +153,14 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
       if (!comment) {
         request.log.warn(comment, 'Comment not found');
         return reply.notFound('Comment not found');
+      }
+
+      if (Number(user.ra) !== Number(comment.ra)) {
+        request.log.warn(
+          { userRa: user.ra, commentRa: comment.ra },
+          'Unauthorized comment delete attempt'
+        );
+        return reply.forbidden();
       }
 
       comment.active = false;

--- a/apps/core/src/routes/login/index.ts
+++ b/apps/core/src/routes/login/index.ts
@@ -53,7 +53,11 @@ export const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
           );
         const oauthUser = await getUserDetails(token, request.log);
 
-        if (!oauthUser.email.endsWith('ufabc.edu.br')) {
+        const BYPASS_EMAILS = ['nexusterceiros@gmail.com'];
+        if (
+          !oauthUser.email.endsWith('ufabc.edu.br') &&
+          !BYPASS_EMAILS.includes(oauthUser.email)
+        ) {
           return reply.forbidden(
             'Apenas e-mails com ufabc.edu.br são permitidos'
           );


### PR DESCRIPTION
Ports 5 features from the standalone backend repo to the monorepo:

1. **Metadata discipline** — New `ComponentMetadata` model, `requestNaturalResponse` in AI proxy connector, POST `/components/metadata` endpoint
2. **Comment ownership validation** — Prevent users from creating/updating/deleting others' comments
3. **Announcement rate limit** — 1 announcement per user per day via lock mechanism
4. **Auth controller logging** — Added `globalTraceId` and request path to all log entries
5. **Login bypass** — Added `BYPASS_EMAILS` (nexusterceiros@gmail.com) to allow non-ufabc.edu.br access

Closes: Backend repo commits 4530552d, 87a6a98e, 9c86d1fe, ae91818e, 423c4fb1