### PR TITLE
fix(ci): move extension VITE_ env vars to job level

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -39,6 +39,11 @@ env:
   CHROME_CLIENT_ID: ${{ secrets.CHROME_EXTENSION_CLIENT_ID }}
   CHROME_CLIENT_SECRET: ${{ secrets.CHROME_EXTENSION_CLIENT_SECRET }}
   CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_EXTENSION_REFRESH_TOKEN }}
+  VITE_AXIOM_TOKEN: ${{ secrets.EXTENSION_AXIOM_INGEST_TOKEN }}
+  VITE_AXIOM_DATASET: ${{ secrets.EXTENSION_AXIOM_DATASET }}
+  VITE_UFABC_NEXT_URL: https://api.v2.ufabcnext.com
+  VITE_UFABC_PARSER_URL: https://ufabc-parser.com/v2
+  VITE_LOG_LEVEL: info
 
 jobs:
   release:
@@ -103,12 +108,6 @@ jobs:
 
       - name: Build extension
         run: pnpm turbo run build --filter=@next/extension
-        env:
-          VITE_AXIOM_TOKEN: ${{ secrets.EXTENSION_AXIOM_INGEST_TOKEN }}
-          VITE_AXIOM_DATASET: ${{ secrets.EXTENSION_AXIOM_DATASET }}
-          VITE_UFABC_NEXT_URL: https://api.v2.ufabcnext.com
-          VITE_UFABC_PARSER_URL: https://ufabc-parser.com/v2
-          VITE_LOG_LEVEL: info
 
       - name: Zip extension
         run: pnpm turbo run zip --filter=@next/extension


### PR DESCRIPTION
## Summary
- `wxt zip` triggers its own internal rebuild (separate from the `Build extension` step's `wxt build`), which was silently overwriting the correctly-built `.output` because the `Zip extension` step's env didn't include `VITE_UFABC_NEXT_URL`/`VITE_UFABC_PARSER_URL`/`VITE_LOG_LEVEL`/`VITE_AXIOM_*`.
- Moves those vars to the job-level `env:` block (alongside the existing `CHROME_*` vars) so every step that touches the build gets them, instead of duplicating per-step.

## Test plan
- [x] Confirmed via run [29242395554](https://github.com/org-nexus-projects/ufabc-next/actions/runs/29242395554) that the uploaded zip was missing the API base URLs despite the Build step's env being set correctly — root-caused to the Zip step's separate env block.
- [ ] Re-run the dryRun workflow on this branch/main and verify the downloaded zip's `content-scripts/sig.js` contains `api.v2.ufabcnext.com`.