### PR TITLE
fix(ci): drop stray /v2 suffix from VITE_UFABC_PARSER_URL

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -42,7 +42,7 @@ env:
   VITE_AXIOM_TOKEN: ${{ secrets.EXTENSION_AXIOM_INGEST_TOKEN }}
   VITE_AXIOM_DATASET: ${{ secrets.EXTENSION_AXIOM_DATASET }}
   VITE_UFABC_NEXT_URL: https://api.v2.ufabcnext.com
-  VITE_UFABC_PARSER_URL: https://ufabc-parser.com/v2
+  VITE_UFABC_PARSER_URL: https://ufabc-parser.com
   VITE_LOG_LEVEL: info
 
 jobs:


### PR DESCRIPTION
## Summary
- `VITE_UFABC_PARSER_URL` was set to `https://ufabc-parser.com/v2`, but the connector's own request paths already prefix `/v2` (e.g. `/v2/components/enrolled` in `packages/connectors/src/ufabc-parser.ts`), producing double `/v2/v2/...` URLs — reported live in prod as `https://ufabc-parser.com/v2/v2/components/enrolled`.
- This value has been wrong since it was introduced; it just wasn't reaching the shipped build until #537 fixed the Turbo env-passthrough.
- Confirmed the correct value is the bare host via `apps/core/.env.prod` (`UFABC_PARSER_URL="https://ufabc-parser.com"`) and the local extension `.env` (`http://localhost:5001`, no `/v2`).

## Test plan
- [x] Built+zipped locally with the corrected value, inspected the bundle: base URL resolves to `https://ufabc-parser.com` with no `/v2` suffix, while `/v2/components/enrolled` etc. still compose correctly from the request-path side