### PR TITLE
fix(connectors): BaseRequester browser logger leaks request/response logs to console

### DIFF
--- a/packages/connectors/src/base-requester.ts
+++ b/packages/connectors/src/base-requester.ts
@@ -146,13 +146,18 @@ export class BaseRequester {
   private async getRootLogger(): Promise<Logger> {
     if (BaseRequester._rootLogger) return BaseRequester._rootLogger;
 
-    const nodeEnv = this.getNodeEnv();
-    const env = nodeEnv === 'production' ? 'production' : 'dev';
-
     if (this.isBrowser()) {
       const { createBrowserLogger } = await import('@next/logger/browser');
-      BaseRequester._rootLogger = createBrowserLogger(env) as unknown as Logger;
+      const viteEnv = (import.meta as { env?: Record<string, string> }).env ?? {};
+      const env = viteEnv.PROD ? 'production' : 'dev';
+      BaseRequester._rootLogger = createBrowserLogger(env, {
+        axiomDataset: viteEnv.VITE_AXIOM_DATASET,
+        axiomToken: viteEnv.VITE_AXIOM_TOKEN,
+        level: viteEnv.VITE_LOG_LEVEL,
+      }) as unknown as Logger;
     } else {
+      const nodeEnv = this.getNodeEnv();
+      const env = nodeEnv === 'production' ? 'production' : 'dev';
       const { createServerLogger } = await import('@next/logger/server');
       BaseRequester._rootLogger = createServerLogger(
         env,


### PR DESCRIPTION
## Summary
Every API call through `UfabcParserConnector`/`NextApiConnector` (built on `BaseRequester`) was logging full request/response details straight to the browser console in production, instead of going to Axiom.

Root cause: `BaseRequester.getRootLogger()` builds its own logger, separate from `apps/extension/src/utils/logger.ts`'s correctly-configured instance. Its environment detection reads `process.env.NODE_ENV`, which doesn't exist in a browser/extension runtime (`globalThis.process` is `undefined` there) — so `getNodeEnv()` always fell back to `'dev'`, and `packages/logger/src/browser.ts`'s `if (env === 'dev') console[...]` gate always fired. On top of that, it never passed Axiom credentials into `createBrowserLogger`, so even a correctly-detected `'production'` env would have just silently dropped these logs instead of shipping them to Axiom.

Fix: use `import.meta.env.PROD` (Vite's build-time flag — this package's raw `.ts` source is bundled directly by the consuming app, so it's correctly replaced, same as `utils/logger.ts` already relies on) and wire through `VITE_AXIOM_DATASET`/`VITE_AXIOM_TOKEN`/`VITE_LOG_LEVEL`.

## Test plan
- [x] Typecheck clean in both `apps/extension` and `apps/core` (this package is shared; the browser branch is unreachable in the Node/server context, verified no new errors)
- [x] Built + zipped locally with test Axiom credentials, inspected the bundle: `BaseRequester`'s internal logger now resolves `env` via `import.meta.env.PROD` → `"production"`, and receives the same Axiom credentials as the app's main logger