### PR TITLE
feat(components): add origin_key and GET /v2/components/:id endpoint

### DIFF
--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -13,8 +13,11 @@ import type {
   ListComponent,
   PopulatedComponent,
 } from '@/schemas/v2/components.js';
-import { listComponentsSchema } from '@/schemas/v2/components.js';
-import { getComponentArchives } from '@/services/components-service.js';
+import {
+  getComponentSchema,
+  listComponentsSchema,
+} from '@/schemas/v2/components.js';
+import { ComponentsService } from '@/services/components-service.js';
 
 const moodleConnector = new MoodleConnector();
 
@@ -36,12 +39,16 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       }
 
       try {
+        const componentsService = new ComponentsService({
+          requestId: request.id,
+        });
         const courses = await moodleConnector.getComponents(
           session.sessionId,
           session.sessKey
         );
 
-        const componentArchives = await getComponentArchives(courses[0]);
+        const componentArchives =
+          await componentsService.getComponentArchives(courses[0]);
         if (componentArchives.error || !componentArchives.data) {
           await request.releaseLock(session.sessionId);
           return reply.badRequest(componentArchives.error ?? 'No data');
@@ -272,6 +279,40 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       },
     },
     url: '/components',
+  });
+
+  app.route({
+    handler: async (request, reply) => {
+      const { id } = request.params;
+      const { with_metadata } = request.query;
+
+      const componentsService = new ComponentsService({
+        requestId: request.id,
+      });
+      const response = await componentsService.findComponentByIdOrOriginKey(
+        id,
+        with_metadata
+      );
+
+      if (!response) {
+        return reply.notFound('Component not found');
+      }
+
+      return reply.status(200).send(response);
+    },
+    method: 'GET',
+    schema: {
+      params: z.object({
+        id: z.string(),
+      }),
+      querystring: z.object({
+        with_metadata: z.coerce.boolean().default(false),
+      }),
+      response: {
+        200: getComponentSchema,
+      },
+    },
+    url: '/components/:id',
   });
 
   app.route({

--- a/apps/core/src/jobs/components-processing.ts
+++ b/apps/core/src/jobs/components-processing.ts
@@ -107,6 +107,7 @@ export const createComponentJob = defineJob(JOB_NAMES.COMPONENTS_PROCESSING)
           credits: component.credits,
           disciplina: subject.name,
           kind: 'api',
+          origin_key: component.componentKey,
           pratica: praticaTeacherId ?? undefined,
           subject: subject._id,
           teoria: teoriaTeacherId ?? undefined,
@@ -143,6 +144,7 @@ export const createComponentJob = defineJob(JOB_NAMES.COMPONENTS_PROCESSING)
         component.courses
           ?.filter((c) => c.category === 'mandatory')
           .map((c) => c.UFCourseId) ?? [],
+      origin_key: component.componentKey,
       pratica: praticaTeacherId ?? undefined,
       quad,
       season: component.season,

--- a/apps/core/src/mappers/component-mapper.ts
+++ b/apps/core/src/mappers/component-mapper.ts
@@ -1,0 +1,25 @@
+import type { Types } from 'mongoose';
+
+import type { Component } from '@/models/Component.js';
+
+type LeanComponent = Component & { _id: Types.ObjectId };
+
+export class ComponentMapper {
+  toResponse(component: LeanComponent, metadata: unknown) {
+    return {
+      _id: component._id.toString(),
+      campus: component.campus,
+      codigo: component.codigo ?? null,
+      disciplina: component.disciplina,
+      disciplina_id: component.disciplina_id ?? null,
+      identifier: component.identifier ?? null,
+      metadata: metadata ?? null,
+      origin_key: component.origin_key ?? null,
+      season: component.season,
+      turma: component.turma,
+      turno: component.turno,
+      uf_cod_turma: component.uf_cod_turma,
+      vagas: component.vagas,
+    };
+  }
+}

--- a/apps/core/src/models/Component.ts
+++ b/apps/core/src/models/Component.ts
@@ -27,6 +27,11 @@ const componentSchema = new Schema(
       type: String,
       required: false,
     },
+    origin_key: {
+      type: String,
+      required: false,
+      default: null,
+    },
     // lista de alunos matriculados no momento
     alunos_matriculados: {
       type: [Number],
@@ -84,6 +89,7 @@ const componentSchema = new Schema(
 );
 
 componentSchema.index({ identifier: 'asc' });
+componentSchema.index({ origin_key: 'asc' });
 
 export type Component = InferSchemaType<typeof componentSchema>;
 export type ComponentDocument = ReturnType<(typeof ComponentModel)['hydrate']>;

--- a/apps/core/src/schemas/v2/components.ts
+++ b/apps/core/src/schemas/v2/components.ts
@@ -43,3 +43,19 @@ export const listComponentItemSchema = z.object({
 export const listComponentsSchema = z.array(listComponentItemSchema);
 
 export type ListComponent = z.infer<typeof listComponentItemSchema>;
+
+export const getComponentSchema = z.object({
+  _id: z.string(),
+  origin_key: z.string().nullable(),
+  disciplina: z.string(),
+  disciplina_id: z.number().nullable(),
+  codigo: z.string().nullable(),
+  turma: z.string(),
+  turno: z.enum(['diurno', 'noturno']),
+  vagas: z.number(),
+  campus: z.enum(['sao bernardo', 'santo andre', 'sbc', 'sa']),
+  season: z.string(),
+  uf_cod_turma: z.string(),
+  identifier: z.string().nullable(),
+  metadata: z.any().nullable().optional(),
+});

--- a/apps/core/src/services/components-service.ts
+++ b/apps/core/src/services/components-service.ts
@@ -1,23 +1,63 @@
+import { Types } from 'mongoose';
+
 import type { MoodleComponent } from '@/connectors/moodle.js';
-
+import { ComponentMapper } from '@/mappers/component-mapper.js';
+import { ComponentModel } from '@/models/Component.js';
+import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
 import { componentArchiveSchema } from '@/schemas/v2/components.js';
+import { logger as defaultLogger } from '@/utils/logger.js';
 
-export async function getComponentArchives(
-  components: MoodleComponent | undefined
-) {
-  const componentArchives = componentArchiveSchema.safeParse(
-    components?.data.courses
-  );
+export class ComponentsService {
+  private readonly mapper = new ComponentMapper();
+  private readonly logger: ReturnType<typeof defaultLogger.child>;
 
-  if (!componentArchives.success) {
+  constructor({ requestId }: { requestId: string }) {
+    this.logger = defaultLogger.child({ requestId });
+  }
+
+  async getComponentArchives(components: MoodleComponent | undefined) {
+    const componentArchives = componentArchiveSchema.safeParse(
+      components?.data.courses
+    );
+
+    if (!componentArchives.success) {
+      return {
+        error: componentArchives.error.message,
+        data: null,
+      };
+    }
+
     return {
-      error: componentArchives.error.message,
-      data: null,
+      error: null,
+      data: componentArchives.data,
     };
   }
 
-  return {
-    error: null,
-    data: componentArchives.data,
-  };
+  async findComponentByIdOrOriginKey(id: string, withMetadata: boolean) {
+    this.logger.debug({ id, withMetadata }, 'Looking up component');
+
+    const searchConditions: Array<Record<string, unknown>> = [
+      { origin_key: id },
+    ];
+    if (Types.ObjectId.isValid(id)) {
+      searchConditions.push({ _id: id });
+    }
+
+    const component = await ComponentModel.findOne({
+      $or: searchConditions,
+    }).lean();
+
+    if (!component) {
+      return null;
+    }
+
+    let metadata = null;
+    if (withMetadata && component.origin_key) {
+      metadata = await ComponentMetadataModel.findOne({
+        'metadata.component_data.componentKey': component.origin_key,
+      }).lean();
+    }
+
+    return this.mapper.toResponse(component, metadata);
+  }
 }


### PR DESCRIPTION
## Summary
- Add `origin_key` field to the `disciplinas` collection (`ComponentModel`), backed by the UFABC parser's `componentKey`, wired into the ingestion job (`components-processing.ts`) on both create and update so new/updated components get it populated.
- Add `GET /v2/components/:id` to fetch a component by its Mongo `_id` or its `origin_key`.
- Add optional `with_metadata` query param that, when true, populates `disciplinas_metadata` by matching `metadata.component_data.componentKey` against the component's `origin_key`.
- Introduce `ComponentsService` (constructed per-request with `{ requestId: request.id }` for trace-scoped logging) and `ComponentMapper` to keep the controller thin.

## Test plan
- [x] `pnpm tsc` passes clean in `apps/core`
- [ ] Manually hit `GET /v2/components/:id` and `GET /v2/components/:id?with_metadata=true` against a seeded component once deployed
- [ ] Confirm the ingestion job populates `origin_key` on the next webhook-triggered component create/update