### PR TITLE
refactor(core): extract error handler into its own plugin

### DIFF
--- a/apps/core/src/app.ts
+++ b/apps/core/src/app.ts
@@ -5,10 +5,7 @@ import dbPlugin from '@next/db/client';
 import type { DatabaseModels } from '@next/db/models';
 import { serializeQueryParams } from '@next/logger/sanitize';
 import type { FastifyInstance, FastifyServerOptions } from 'fastify';
-import {
-  RequestValidationError,
-  ResponseSerializationError,
-} from 'fastify-zod-openapi';
+import { RequestValidationError } from 'fastify-zod-openapi';
 import type { Mongoose } from 'mongoose';
 
 import { authenticationController } from './controllers/authentication-controller.js';
@@ -19,6 +16,7 @@ import studentsController from './controllers/students-controller.js';
 import { UfabcParserIncomingWebhookController } from './controllers/ufabc-parser-webhook-controller.js';
 import { authenticateBoard } from './hooks/board-authenticate.js';
 import awsV2Plugin from './plugins/v2/aws.js';
+import errorHandlerPlugin from './plugins/v2/error-handler.js';
 import queueV2Plugin from './plugins/v2/queue.js';
 import redisV2Plugin from './plugins/v2/redis.js';
 import { setupV2Routes } from './plugins/v2/setup.js';
@@ -76,76 +74,7 @@ export async function buildApp(
     return new Error(message);
   });
 
-  app.setErrorHandler((error, request, reply) => {
-    reply.error = error as Error;
-
-    if (error instanceof ResponseSerializationError) {
-      reply.status(422);
-      reply.send({
-        originalError: error.validation?.[0]?.params.error ?? null,
-        zodIssues: error.validation?.map((err) => err.params.issue) ?? [],
-      });
-      return;
-    }
-
-    if (
-      error &&
-      typeof error === 'object' &&
-      'validation' in error &&
-      error.validation
-    ) {
-      const validationError = error as Error & { validation: unknown[] };
-
-      request.log.warn(
-        {
-          error: validationError,
-          request: {
-            method: request.method,
-            params: request.params,
-            query: serializeQueryParams(request.query),
-            url: request.url,
-          },
-        },
-        validationError.message
-      );
-
-      reply.status(400);
-      reply.send({
-        error: 'Bad Request',
-        message: validationError.message,
-        statusCode: 400,
-        validation: validationError.validation,
-      });
-      return;
-    }
-
-    if (error instanceof Error) {
-      request.log.error(
-        {
-          error,
-          request: {
-            method: request.method,
-            params: request.params,
-            query: serializeQueryParams(request.query),
-            url: request.url,
-          },
-        },
-        error.message
-      );
-
-      reply.status(500);
-      reply.send({
-        error: error.name,
-        message: error.message,
-        statusCode: 500,
-      });
-      return;
-    }
-
-    if (!error) {
-      return;
-    }
-  });
+  await app.register(errorHandlerPlugin);
 
   app.setNotFoundHandler((request, reply) => {
     request.log.warn(

--- a/apps/core/src/errors/base-error.ts
+++ b/apps/core/src/errors/base-error.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+export const errorJsonSchema = z.object({
+  additionalData: z.record(z.string(), z.unknown()).nullable().optional(),
+  code: z.string(),
+  description: z.string(),
+  httpStatus: z.number(),
+  title: z.string(),
+});
+
+export const errorHttpSchema = z.object({
+  additionalData: z.record(z.string(), z.unknown()).nullable().optional(),
+  code: z.string(),
+  description: z.string(),
+  statusCode: z.number(),
+  title: z.string(),
+});
+
+export type ErrorJson = z.infer<typeof errorJsonSchema>;
+export type ErrorHttp = z.infer<typeof errorHttpSchema>;
+
+export class NextError extends Error {
+  readonly title: string;
+  readonly code: string;
+  readonly httpStatus: number;
+  description: string;
+  additionalData: Record<string, unknown> | null | undefined;
+
+  get status(): number {
+    return this.httpStatus;
+  }
+
+  get statusCode(): number {
+    return this.httpStatus;
+  }
+
+  constructor(
+    title: string,
+    code: string,
+    httpStatus: number,
+    description: string,
+    additionalData?: Record<string, unknown> | null
+  ) {
+    super(title);
+    this.name = 'NextError';
+    this.title = title;
+    this.description = description;
+    this.code = code;
+    this.httpStatus = httpStatus;
+    this.additionalData = additionalData ?? null;
+  }
+
+  toJson(): ErrorJson {
+    const json: ErrorJson = {
+      additionalData: this.additionalData ?? null,
+      code: this.code,
+      description: this.description,
+      httpStatus: this.httpStatus,
+      title: this.title,
+    };
+
+    return errorJsonSchema.parse(json);
+  }
+
+  toHttp(): ErrorHttp {
+    const http: ErrorHttp = {
+      additionalData: this.additionalData ?? null,
+      code: this.code,
+      description: this.description,
+      statusCode: this.httpStatus,
+      title: this.title,
+    };
+
+    return errorHttpSchema.parse(http);
+  }
+}

--- a/apps/core/src/plugins/v2/error-handler.ts
+++ b/apps/core/src/plugins/v2/error-handler.ts
@@ -1,0 +1,96 @@
+import { serializeQueryParams } from '@next/logger/sanitize';
+import type {
+  FastifyError,
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+} from 'fastify';
+import { fastifyPlugin as fp } from 'fastify-plugin';
+import {
+  RequestValidationError,
+  ResponseSerializationError,
+} from 'fastify-zod-openapi';
+
+import { NextError } from '@/errors/base-error.js';
+
+export default fp(
+  (app: FastifyInstance) => {
+    app.setErrorHandler(
+      (error: FastifyError, request: FastifyRequest, reply: FastifyReply) => {
+        reply.error = error as Error;
+
+        const requestContext = {
+          method: request.method,
+          params: request.params,
+          query: serializeQueryParams(request.query),
+          url: request.url,
+        };
+
+        if (error instanceof ResponseSerializationError) {
+          reply.status(422);
+          reply.send({
+            originalError: error.validation?.[0]?.params.error ?? null,
+            zodIssues: error.validation?.map((err) => err.params.issue) ?? [],
+          });
+          return;
+        }
+
+        if (
+          error instanceof RequestValidationError ||
+          (error &&
+            typeof error === 'object' &&
+            'validation' in error &&
+            error.validation)
+        ) {
+          const validationError = error as Error & { validation: unknown[] };
+
+          request.log.warn(
+            { error: validationError, request: requestContext },
+            validationError.message
+          );
+
+          reply.status(400);
+          reply.send({
+            error: 'Bad Request',
+            message: validationError.message,
+            statusCode: 400,
+            validation: validationError.validation,
+          });
+          return;
+        }
+
+        if (error instanceof NextError) {
+          request.log.warn(
+            { error, request: requestContext },
+            error.description
+          );
+
+          const httpBody = error.toHttp();
+          reply.status(httpBody.statusCode);
+          reply.send(httpBody);
+          return;
+        }
+
+        if (error instanceof Error) {
+          request.log.error(
+            { error, request: requestContext },
+            error.message
+          );
+
+          reply.status(500);
+          reply.send({
+            error: error.name,
+            message: error.message,
+            statusCode: 500,
+          });
+          return;
+        }
+
+        if (!error) {
+          return;
+        }
+      }
+    );
+  },
+  { name: 'error-handler' }
+);


### PR DESCRIPTION
Extracts the inline `app.setErrorHandler` in `apps/core/src/app.ts` into its own plugin, following the same structure as ufabc-next-backend PR #244: a `NextError` base class (`toJson()`/`toHttp()`, `status`/`statusCode` getters) under `errors/`, and the handler itself moved to `plugins/v2/error-handler.ts` with a `NextError` branch added alongside the existing `ResponseSerializationError`/validation/generic-`Error` cases. Route handlers are untouched.
