### PR TITLE
feat(archive-engine): port archive engine from legacy backend

### DIFF
--- a/apps/core/src/app.ts
+++ b/apps/core/src/app.ts
@@ -53,7 +53,7 @@ export async function buildApp(
   });
 
   await app.register(redisV2Plugin);
-  await app.register(dbPlugin);
+  await app.register(dbPlugin, { config: app.config });
   await app.register(queueV2Plugin, {
     redisURL: new URL(app.config.REDIS_CONNECTION_URL),
   });

--- a/apps/core/src/connectors/moodle.ts
+++ b/apps/core/src/connectors/moodle.ts
@@ -39,21 +39,34 @@ export type MoodleComponent = {
   };
 };
 
+export type MoodleConnectorOptions = {
+  globalTraceId?: string;
+};
+
+let moodleConnectorInstance: MoodleConnector | null = null;
+
 export class MoodleConnector extends BaseRequester {
   private lastRequestTime = 0;
   private readonly minRequestInterval = 300;
 
-  constructor(globalTraceId?: string) {
-    super('https://moodle.ufabc.edu.br', globalTraceId);
+  // singleton constructor: returns the cached instance instead of constructing a new one
+  constructor(options: MoodleConnectorOptions = {}) {
+    if (moodleConnectorInstance) {
+      return moodleConnectorInstance;
+    }
+
+    super('https://moodle.ufabc.edu.br', options.globalTraceId);
+
+    moodleConnectorInstance = this;
   }
 
   async validateToken(sessionId: string, sessKey: string) {
     const body = [
       {
+        args: { classification: 'all', limit: 1, offset: 0 },
         index: 0,
         methodname:
           'core_course_get_enrolled_courses_by_timeline_classification',
-        args: { offset: 0, limit: 1, classification: 'all' },
       },
     ];
 
@@ -62,16 +75,16 @@ export class MoodleConnector extends BaseRequester {
     headers.set('Content-Type', 'application/json');
     headers.set('X-Requested-With', 'XMLHttpRequest');
 
-    const response = await this.request<Array<MoodleResponse>>(
+    const response = await this.request<MoodleResponse[]>(
       '/lib/ajax/service.php?',
       {
+        body,
+        headers,
         method: 'POST',
         query: {
           sesskey: sessKey,
         },
-        headers,
-        body,
-        timeout: 5_000,
+        timeout: 5000,
       }
     );
 
@@ -82,23 +95,23 @@ export class MoodleConnector extends BaseRequester {
     const headers = new Headers();
     headers.set('Cookie', `MoodleSession=${sessionId}`);
 
-    const response = await this.request<Array<MoodleComponent>>(
+    const response = await this.request<MoodleComponent[]>(
       '/lib/ajax/service.php',
       {
+        body: [
+          {
+            args: { classification: 'all', limit: 0, offset: 0 },
+            index: 0,
+            methodname:
+              'core_course_get_enrolled_courses_by_timeline_classification',
+          },
+        ],
+        credentials: 'include',
+        headers,
         method: 'POST',
         query: {
           sesskey: sessKey,
         },
-        headers,
-        credentials: 'include',
-        body: [
-          {
-            index: 0,
-            methodname:
-              'core_course_get_enrolled_courses_by_timeline_classification',
-            args: { offset: 0, limit: 0, classification: 'all' },
-          },
-        ],
       }
     );
     return response;
@@ -109,12 +122,12 @@ export class MoodleConnector extends BaseRequester {
     headers.set('Cookie', `MoodleSession=${sessionId}`);
 
     const response = await this.request<string>(url, {
-      headers,
       credentials: 'include',
-      responseType: 'text',
+      headers,
       query: {
         id,
       },
+      responseType: 'text',
     });
 
     return response;
@@ -125,9 +138,9 @@ export class MoodleConnector extends BaseRequester {
     headers.set('Cookie', `MoodleSession=${sessionId}`);
 
     const response = await this.request<string>('/user/profile.php', {
-      method: 'GET',
-      headers,
       credentials: 'include',
+      headers,
+      method: 'GET',
       responseType: 'text',
       timeout: 10_000,
     });
@@ -140,8 +153,8 @@ export class MoodleConnector extends BaseRequester {
     headers.set('Cookie', `MoodleSession=${sessionId}`);
 
     const response = await this.request<string>('/user/index.php', {
-      method: 'GET',
       headers,
+      method: 'GET',
       query: { id: courseId, roleid: 3 },
       responseType: 'text',
       timeout: 10_000,
@@ -170,14 +183,14 @@ export class MoodleConnector extends BaseRequester {
       let contentType: string | null = null;
 
       const response = await this.requestRaw(url, {
-        method: 'HEAD',
         headers: {
           Cookie: `MoodleSession=${sessionId}`,
           sesskey: sessionKey,
         },
+        method: 'HEAD',
         retry: 1,
         retryDelay: 500,
-        timeout: 10000,
+        timeout: 10_000,
       });
 
       finalUrl = response.url || url;
@@ -188,25 +201,25 @@ export class MoodleConnector extends BaseRequester {
         finalUrl.toLowerCase().endsWith('.pdf');
 
       return {
-        isPdf,
         finalUrl: isPdf ? finalUrl : undefined,
+        isPdf,
       };
-    } catch (error) {
+    } catch {
       // Some servers don't support HEAD requests, try GET with range header
       try {
         let finalUrl = url;
         let contentType: string | null = null;
 
         const response = await this.requestRaw(url, {
-          method: 'GET',
           credentials: 'include',
           headers: {
             Cookie: `MoodleSession=${sessionId}`,
-            sesskey: sessionKey,
             Range: 'bytes=0-0', // Only get first byte
+            sesskey: sessionKey,
           },
+          method: 'GET',
           retry: 0,
-          timeout: 10000,
+          timeout: 10_000,
         });
 
         finalUrl = response.url || url;
@@ -217,12 +230,12 @@ export class MoodleConnector extends BaseRequester {
           finalUrl.toLowerCase().endsWith('.pdf');
 
         return {
-          isPdf,
           finalUrl: isPdf ? finalUrl : undefined,
+          isPdf,
         };
       } catch {
         // If both fail, it's likely not accessible or not a PDF
-        return { isPdf: false, finalUrl: undefined };
+        return { finalUrl: undefined, isPdf: false };
       }
     }
   }

--- a/apps/core/src/connectors/moodle.ts
+++ b/apps/core/src/connectors/moodle.ts
@@ -43,8 +43,8 @@ export class MoodleConnector extends BaseRequester {
   private lastRequestTime = 0;
   private readonly minRequestInterval = 300;
 
-  constructor() {
-    super('https://moodle.ufabc.edu.br');
+  constructor(globalTraceId?: string) {
+    super('https://moodle.ufabc.edu.br', globalTraceId);
   }
 
   async validateToken(sessionId: string, sessKey: string) {
@@ -115,6 +115,36 @@ export class MoodleConnector extends BaseRequester {
       query: {
         id,
       },
+    });
+
+    return response;
+  }
+
+  async getUserPage(sessionId: string) {
+    const headers = new Headers();
+    headers.set('Cookie', `MoodleSession=${sessionId}`);
+
+    const response = await this.request<string>('/user/profile.php', {
+      method: 'GET',
+      headers,
+      credentials: 'include',
+      responseType: 'text',
+      timeout: 10_000,
+    });
+
+    return response;
+  }
+
+  async getUsersByCoursePage(sessionId: string, courseId: number) {
+    const headers = new Headers();
+    headers.set('Cookie', `MoodleSession=${sessionId}`);
+
+    const response = await this.request<string>('/user/index.php', {
+      method: 'GET',
+      headers,
+      query: { id: courseId, roleid: 3 },
+      responseType: 'text',
+      timeout: 10_000,
     });
 
     return response;

--- a/apps/core/src/connectors/s3-connector.ts
+++ b/apps/core/src/connectors/s3-connector.ts
@@ -1,4 +1,5 @@
 import {
+  GetObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   type S3Client,
@@ -16,6 +17,14 @@ export class S3Connector extends BaseAWSConnector<S3Client> {
       Bucket: bucket,
       Key: key,
       Body: body,
+    });
+    return this.client.send(command);
+  }
+
+  async getObject(bucket: string, key: string) {
+    const command = new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
     });
     return this.client.send(command);
   }

--- a/apps/core/src/connectors/s3-connector.ts
+++ b/apps/core/src/connectors/s3-connector.ts
@@ -2,8 +2,8 @@ import {
   GetObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
-  type S3Client,
 } from '@aws-sdk/client-s3';
+import type { S3Client } from '@aws-sdk/client-s3';
 
 import { BaseAWSConnector } from './base-aws-connector.js';
 
@@ -14,11 +14,11 @@ export class S3Connector extends BaseAWSConnector<S3Client> {
     body: Buffer | Uint8Array | Blob | string
   ) {
     const command = new PutObjectCommand({
+      Body: body,
       Bucket: bucket,
       Key: key,
-      Body: body,
     });
-    return this.client.send(command);
+    return await this.client.send(command);
   }
 
   async getObject(bucket: string, key: string) {
@@ -26,7 +26,7 @@ export class S3Connector extends BaseAWSConnector<S3Client> {
       Bucket: bucket,
       Key: key,
     });
-    return this.client.send(command);
+    return await this.client.send(command);
   }
 
   async list(bucket: string) {
@@ -44,8 +44,8 @@ export class S3Connector extends BaseAWSConnector<S3Client> {
       files.push({
         key: item.Key,
         lastModified: item.LastModified,
-        size: this.#formatFileSize(item.Size),
         rawSize: item.Size,
+        size: this.#formatFileSize(item.Size),
       });
     }
     return files;

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -304,7 +304,7 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
   app.route({
     handler: async (request, reply) => {
-      const { componentId } = request.params as { componentId: string };
+      const { componentId } = request.params;
 
       const componentsService = new ComponentsService({
         globalTraceId: request.id,

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -1,20 +1,26 @@
 import { currentQuad } from '@next/utils';
+import { load } from 'cheerio';
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
 import { AIProxyConnector } from '@/connectors/ai-proxy.js';
 import { MoodleConnector } from '@/connectors/moodle.js';
-import { JOB_NAMES } from '@/constants.js';
+import {
+  EmailVerificationFailed,
+  UserWithoutRA,
+} from '@/errors/custom-errors.js';
 import { jwtVerifyHook } from '@/hooks/jwt-verify.js';
 import { moodleSession } from '@/hooks/moodle-session.js';
+import { validateInternalTokenAuthHook } from '@/hooks/validate-token.js';
 import { ComponentModel } from '@/models/Component.js';
+import { ComponentArchiveModel } from '@/models/ComponentArchive.js';
 import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
 import type { ComponentMetadata } from '@/models/ComponentMetadata.js';
+import { UserModel } from '@/models/User.js';
 import type {
   ListComponent,
   PopulatedComponent,
 } from '@/schemas/v2/components.js';
-import { validateInternalTokenAuthHook } from '@/hooks/validate-token.js';
 import {
   getComponentSchema,
   listComponentsSchema,
@@ -31,8 +37,9 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         sessKey: string;
       };
       const hasLock = await request.acquireLock(session.sessionId, '24h');
+      const isDevelopment = app.config.NODE_ENV !== 'prod';
 
-      if (!hasLock) {
+      if (!hasLock && !isDevelopment) {
         request.log.debug(
           { sessionId: session.sessionId },
           'Archives already processing'
@@ -40,45 +47,54 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         return reply.status(202).send({ status: 'success' });
       }
 
-      try {
-        const componentsService = new ComponentsService({
-          requestId: request.id,
-        });
-        const courses = await moodleConnector.getComponents(
-          session.sessionId,
-          session.sessKey
-        );
+      const requestConnector = new MoodleConnector(request.id);
+      const userPage = await requestConnector.getUserPage(session.sessionId);
+      const $ = load(userPage);
+      const email = $(
+        '#region-main > div > div > div.userprofile > div > section:nth-child(1) > div > ul > li:nth-child(2) > dl > dd > a'
+      ).text();
 
-        const componentArchives =
-          await componentsService.getComponentArchives(courses[0]);
-        if (componentArchives.error || !componentArchives.data) {
-          await request.releaseLock(session.sessionId);
-          return reply.badRequest(componentArchives.error ?? 'No data');
-        }
-
-        await app.manager.dispatch(JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING, {
-          component: componentArchives.data,
-          globalTraceId: request.id,
-          session,
-        });
-
-        return reply.status(202).send({
-          status: 'success',
-        });
-      } catch (error) {
-        request.log.error(error, 'Error getting archives');
-        await request.releaseLock(session.sessionId);
-        return reply.internalServerError('Error getting archives');
+      if (!email) {
+        throw new EmailVerificationFailed();
       }
+
+      const user = await UserModel.findOne({ email });
+
+      if (!user?.ra) {
+        request.log.warn(
+          { email },
+          'User does not have RA, skipping enrollment check'
+        );
+        throw new UserWithoutRA();
+      }
+
+      const componentsService = new ComponentsService({
+        manager: app.manager,
+        globalTraceId: request.id,
+      });
+      await componentsService.processComponentArchives(session);
+
+      return reply.status(202).send({
+        status: 'success',
+      });
     },
     method: 'POST',
     preHandler: [moodleSession],
+    onError: async (request) => {
+      const session = request.requestContext.get('moodleSession') as
+        | { sessionId: string }
+        | undefined;
+      if (session) {
+        await request.releaseLock(session.sessionId);
+      }
+    },
     schema: {
       headers: z.object({
         'session-id': z.string(),
         'sess-key': z.string(),
       }),
       response: {
+        200: z.any(),
         202: z.object({
           status: z.string(),
         }),
@@ -319,18 +335,110 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
   app.route({
     handler: async (request, reply) => {
+      const { componentId } = request.params as { componentId: string };
+
+      const archives = await ComponentArchiveModel.find({
+        component: componentId,
+      })
+        .populate('component', 'disciplina codigo turma turno season')
+        .sort({ createdAt: -1 })
+        .lean();
+
+      const data = archives.map((archive) => ({
+        _id: archive._id.toString(),
+        s3_key: archive.s3_key ?? null,
+        original_url: archive.original_url,
+        file_name: archive.file_name ?? null,
+        status: archive.status,
+        source: archive.source,
+        timeline: (archive.timeline ?? []).map((event) => ({
+          status: event.status,
+          timestamp: event.timestamp?.toISOString() ?? '',
+          metadata: event.metadata,
+        })),
+        createdAt: archive.createdAt?.toISOString() ?? '',
+        component: archive.component ?? null,
+      }));
+
+      return await reply.status(200).send({ status: 'success', data });
+    },
+    method: 'GET',
+    schema: {
+      params: z.object({
+        componentId: z.string(),
+      }),
+      response: {
+        200: z.object({
+          status: z.string(),
+          data: z.array(z.any()),
+        }),
+      },
+    },
+    url: '/components/:componentId/archives',
+  });
+
+  app.route({
+    handler: async (request, reply) => {
+      const { archiveId } = request.params as { archiveId: string };
+
+      const archive = await ComponentArchiveModel.findById(archiveId);
+      if (!archive || typeof archive.s3_key !== 'string') {
+        return await reply.code(404).send({
+          status: 'error',
+          message: 'Archive not found or not yet stored',
+        });
+      }
+
+      const s3Object = await app.aws.s3.getObject(
+        app.config.AWS_BUCKET,
+        archive.s3_key
+      );
+
+      const filename = archive.file_name ?? 'document.pdf';
+      const contentType = s3Object.ContentType ?? 'application/octet-stream';
+
+      if (!s3Object.Body) {
+        return await reply.code(500).send({
+          status: 'error',
+          message: 'Empty file on S3',
+        });
+      }
+
+      return await reply
+        .type(contentType)
+        .header('Content-Disposition', `attachment; filename="${filename}"`)
+        .send(s3Object.Body);
+    },
+    method: 'GET',
+    schema: {
+      params: z.object({
+        componentId: z.string(),
+        archiveId: z.string(),
+      }),
+      response: {
+        200: z.any(),
+        404: z.object({ status: z.string(), message: z.string() }),
+        500: z.object({ status: z.string(), message: z.string() }),
+      },
+    },
+    url: '/components/:componentId/archives/:archiveId/download',
+  });
+
+  app.route({
+    handler: async (request, reply) => {
       const { config } = request.server;
-      const aiConnector = new AIProxyConnector(config.NEXT_AGENT_URL, 'whatsapp');
+      const aiConnector = new AIProxyConnector(
+        config.NEXT_AGENT_URL,
+        'whatsapp'
+      );
 
       const { externalKey, season } = request.query;
       const { userMessage } = request.body as { userMessage: string };
-
 
       let component: ComponentMetadata | null = null;
       let response: any = null;
 
       if (externalKey) {
-
         component = await ComponentMetadataModel.findOne({
           'metadata.component_data.componentKey': externalKey,
           'metadata.component_data.season': season,
@@ -351,7 +459,6 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
           userMessage
         );
       }
-
 
       return reply.status(200).send({
         status: 'success',
@@ -377,11 +484,6 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
     },
     url: '/components/metadata',
   });
-
-
 };
-
-
-
 
 export default componentsController;

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -1,14 +1,9 @@
 import { currentQuad } from '@next/utils';
-import { load } from 'cheerio';
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
 import { AIProxyConnector } from '@/connectors/ai-proxy.js';
 import { MoodleConnector } from '@/connectors/moodle.js';
-import {
-  EmailVerificationFailed,
-  UserWithoutRA,
-} from '@/errors/custom-errors.js';
 import { jwtVerifyHook } from '@/hooks/jwt-verify.js';
 import type { Session } from '@/hooks/moodle-session.js';
 import { moodleSession } from '@/hooks/moodle-session.js';
@@ -17,7 +12,6 @@ import { ComponentModel } from '@/models/Component.js';
 import { ComponentArchiveModel } from '@/models/ComponentArchive.js';
 import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
 import type { ComponentMetadata } from '@/models/ComponentMetadata.js';
-import { UserModel } from '@/models/User.js';
 import type {
   ListComponent,
   PopulatedComponent,
@@ -49,31 +43,11 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         return await reply.status(202).send({ status: 'success' });
       }
 
-      const requestConnector = new MoodleConnector(request.id);
-      const userPage = await requestConnector.getUserPage(session.sessionId);
-      const $ = load(userPage);
-      const email = $(
-        '#region-main > div > div > div.userprofile > div > section:nth-child(1) > div > ul > li:nth-child(2) > dl > dd > a'
-      ).text();
-
-      if (!email) {
-        throw new EmailVerificationFailed();
-      }
-
-      const user = await UserModel.findOne({ email });
-
-      if (user?.ra === undefined || user.ra === null || user.ra === 0) {
-        request.log.warn(
-          { email },
-          'User does not have RA, skipping enrollment check'
-        );
-        throw new UserWithoutRA();
-      }
-
       const componentsService = new ComponentsService({
         globalTraceId: request.id,
         manager: app.manager,
       });
+      await componentsService.verifyUserForArchives(session);
       await componentsService.processComponentArchives(session);
 
       return await reply.status(202).send({

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -9,7 +9,6 @@ import type { Session } from '@/hooks/moodle-session.js';
 import { moodleSession } from '@/hooks/moodle-session.js';
 import { validateInternalTokenAuthHook } from '@/hooks/validate-token.js';
 import { ComponentModel } from '@/models/Component.js';
-import { ComponentArchiveModel } from '@/models/ComponentArchive.js';
 import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
 import type { ComponentMetadata } from '@/models/ComponentMetadata.js';
 import type {
@@ -68,7 +67,6 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         'session-id': z.string(),
       }),
       response: {
-        200: z.any(),
         202: z.object({
           status: z.string(),
         }),
@@ -308,28 +306,11 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
     handler: async (request, reply) => {
       const { componentId } = request.params as { componentId: string };
 
-      const archives = await ComponentArchiveModel.find({
-        component: componentId,
-      })
-        .populate('component', 'disciplina codigo turma turno season')
-        .sort({ createdAt: -1 })
-        .lean();
-
-      const data = archives.map((archive) => ({
-        _id: archive._id.toString(),
-        component: archive.component ?? null,
-        createdAt: archive.createdAt?.toISOString() ?? '',
-        file_name: archive.file_name ?? null,
-        original_url: archive.original_url,
-        s3_key: archive.s3_key ?? null,
-        source: archive.source,
-        status: archive.status,
-        timeline: (archive.timeline ?? []).map((event) => ({
-          metadata: event.metadata as unknown,
-          status: event.status,
-          timestamp: event.timestamp?.toISOString() ?? '',
-        })),
-      }));
+      const componentsService = new ComponentsService({
+        globalTraceId: request.id,
+        manager: app.manager,
+      });
+      const data = await componentsService.listComponentArchives(componentId);
 
       return await reply.status(200).send({ data, status: 'success' });
     },
@@ -352,35 +333,24 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
     handler: async (request, reply) => {
       const { archiveId } = request.params as { archiveId: string };
 
-      const archive = await ComponentArchiveModel.findById(archiveId);
-      if (!archive || typeof archive.s3_key !== 'string') {
-        return await reply.code(404).send({
-          message: 'Archive not found or not yet stored',
-          status: 'error',
-        });
-      }
-
-      const s3Object = await app.aws.s3.getObject(
-        app.config.AWS_BUCKET,
-        archive.s3_key
-      );
-
-      const filename = archive.file_name ?? 'document.pdf';
-      const contentType = s3Object.ContentType ?? 'application/octet-stream';
-
-      if (!s3Object.Body) {
-        return await reply.code(500).send({
-          message: 'Empty file on S3',
-          status: 'error',
-        });
-      }
+      const componentsService = new ComponentsService({
+        globalTraceId: request.id,
+        manager: app.manager,
+      });
+      const { body, contentType, filename } =
+        await componentsService.getArchiveDownload(
+          archiveId,
+          app.aws.s3,
+          app.config.AWS_BUCKET
+        );
 
       return await reply
         .type(contentType)
         .header('Content-Disposition', `attachment; filename="${filename}"`)
-        .send(s3Object.Body);
+        .send(body);
     },
     method: 'GET',
+    preHandler: [validateInternalTokenAuthHook],
     schema: {
       params: z.object({
         archiveId: z.string(),
@@ -388,8 +358,6 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       }),
       response: {
         200: z.any(),
-        404: z.object({ message: z.string(), status: z.string() }),
-        500: z.object({ message: z.string(), status: z.string() }),
       },
     },
     url: '/components/:componentId/archives/:archiveId/download',

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -5,8 +5,7 @@ import { z } from 'zod';
 import { AIProxyConnector } from '@/connectors/ai-proxy.js';
 import { MoodleConnector } from '@/connectors/moodle.js';
 import { jwtVerifyHook } from '@/hooks/jwt-verify.js';
-import type { Session } from '@/hooks/moodle-session.js';
-import { moodleSession } from '@/hooks/moodle-session.js';
+import { isSession, moodleSession } from '@/hooks/moodle-session.js';
 import { validateInternalTokenAuthHook } from '@/hooks/validate-token.js';
 import { ComponentModel } from '@/models/Component.js';
 import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
@@ -26,7 +25,8 @@ const moodleConnector = new MoodleConnector();
 const componentsController: FastifyPluginAsyncZod = async (app) => {
   app.route({
     handler: async (request, reply) => {
-      const session = request.requestContext.get<Session>('moodleSession');
+      const rawSession = request.requestContext.get('moodleSession');
+      const session = isSession(rawSession) ? rawSession : undefined;
       if (!session) {
         return await reply.unauthorized();
       }
@@ -55,7 +55,8 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
     },
     method: 'POST',
     onError: async (request) => {
-      const session = request.requestContext.get<Session>('moodleSession');
+      const rawSession = request.requestContext.get('moodleSession');
+      const session = isSession(rawSession) ? rawSession : undefined;
       if (session !== undefined) {
         await request.releaseLock(session.sessionId);
       }
@@ -77,7 +78,8 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
   app.route({
     handler: async (request, reply) => {
-      const session = request.requestContext.get<Session>('moodleSession');
+      const rawSession = request.requestContext.get('moodleSession');
+      const session = isSession(rawSession) ? rawSession : undefined;
       if (!session) {
         return await reply.unauthorized();
       }

--- a/apps/core/src/controllers/components-controller.ts
+++ b/apps/core/src/controllers/components-controller.ts
@@ -10,6 +10,7 @@ import {
   UserWithoutRA,
 } from '@/errors/custom-errors.js';
 import { jwtVerifyHook } from '@/hooks/jwt-verify.js';
+import type { Session } from '@/hooks/moodle-session.js';
 import { moodleSession } from '@/hooks/moodle-session.js';
 import { validateInternalTokenAuthHook } from '@/hooks/validate-token.js';
 import { ComponentModel } from '@/models/Component.js';
@@ -32,10 +33,11 @@ const moodleConnector = new MoodleConnector();
 const componentsController: FastifyPluginAsyncZod = async (app) => {
   app.route({
     handler: async (request, reply) => {
-      const session = request.requestContext.get('moodleSession')! as {
-        sessionId: string;
-        sessKey: string;
-      };
+      const session = request.requestContext.get<Session>('moodleSession');
+      if (!session) {
+        return await reply.unauthorized();
+      }
+
       const hasLock = await request.acquireLock(session.sessionId, '24h');
       const isDevelopment = app.config.NODE_ENV !== 'prod';
 
@@ -44,7 +46,7 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
           { sessionId: session.sessionId },
           'Archives already processing'
         );
-        return reply.status(202).send({ status: 'success' });
+        return await reply.status(202).send({ status: 'success' });
       }
 
       const requestConnector = new MoodleConnector(request.id);
@@ -60,7 +62,7 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
       const user = await UserModel.findOne({ email });
 
-      if (!user?.ra) {
+      if (user?.ra === undefined || user.ra === null || user.ra === 0) {
         request.log.warn(
           { email },
           'User does not have RA, skipping enrollment check'
@@ -69,29 +71,27 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       }
 
       const componentsService = new ComponentsService({
-        manager: app.manager,
         globalTraceId: request.id,
+        manager: app.manager,
       });
       await componentsService.processComponentArchives(session);
 
-      return reply.status(202).send({
+      return await reply.status(202).send({
         status: 'success',
       });
     },
     method: 'POST',
-    preHandler: [moodleSession],
     onError: async (request) => {
-      const session = request.requestContext.get('moodleSession') as
-        | { sessionId: string }
-        | undefined;
-      if (session) {
+      const session = request.requestContext.get<Session>('moodleSession');
+      if (session !== undefined) {
         await request.releaseLock(session.sessionId);
       }
     },
+    preHandler: [moodleSession],
     schema: {
       headers: z.object({
-        'session-id': z.string(),
         'sess-key': z.string(),
+        'session-id': z.string(),
       }),
       response: {
         200: z.any(),
@@ -105,17 +105,18 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
   app.route({
     handler: async (request, reply) => {
-      const session = request.requestContext.get('moodleSession')! as {
-        sessionId: string;
-        sessKey: string;
-      };
+      const session = request.requestContext.get<Session>('moodleSession');
+      if (!session) {
+        return await reply.unauthorized();
+      }
+
       const components = await moodleConnector.getComponents(
         session.sessionId,
         session.sessKey
       );
-      return reply.status(200).send({
-        status: 'success',
+      return await reply.status(200).send({
         data: components,
+        status: 'success',
       });
     },
     method: 'GET',
@@ -123,8 +124,8 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
     schema: {
       response: {
         200: z.object({
-          status: z.string(),
           data: z.any().array(),
+          status: z.string(),
         }),
       },
     },
@@ -134,9 +135,9 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
   app.route({
     handler: async (_request, reply) => {
       const uploads = await app.aws.s3.list(app.config.AWS_BUCKET);
-      return reply.status(200).send({
-        status: 'success',
+      return await reply.status(200).send({
         data: uploads,
+        status: 'success',
       });
     },
     method: 'GET',
@@ -150,24 +151,24 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       const requested = await ComponentModel.aggregate([
         {
           $match: {
-            season,
             $or: [{ groupURL: null }, { groupURL: { $exists: false } }],
+            season,
           },
         },
         {
           $lookup: {
+            as: 'teoriaTeacher',
+            foreignField: '_id',
             from: 'teachers',
             localField: 'teoria',
-            foreignField: '_id',
-            as: 'teoriaTeacher',
           },
         },
         {
           $lookup: {
+            as: 'praticaTeacher',
+            foreignField: '_id',
             from: 'teachers',
             localField: 'pratica',
-            foreignField: '_id',
-            as: 'praticaTeacher',
           },
         },
         {
@@ -186,16 +187,16 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
             allStudentsInGroup: { $addToSet: '$alunos_matriculados' },
             components: {
               $push: {
-                disciplina_id: '$disciplina_id',
                 amount_studentsId: '$$ROOT.quantidade_alunos_matriculados',
-                nome: '$disciplina',
-                turma: '$turma',
-                vagas: '$vagas',
-                uf_cod_turma: '$uf_cod_turma',
                 component_code: '$codigo',
+                disciplina_id: '$disciplina_id',
+                nome: '$disciplina',
                 // Extract the teacher name immediately during the push
-                teoria: { $arrayElemAt: ['$teoriaTeacher.name', 0] },
                 pratica: { $arrayElemAt: ['$praticaTeacher.name', 0] },
+                teoria: { $arrayElemAt: ['$teoriaTeacher.name', 0] },
+                turma: '$turma',
+                uf_cod_turma: '$uf_cod_turma',
+                vagas: '$vagas',
               },
             },
           },
@@ -203,25 +204,25 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         {
           $project: {
             _id: 0,
-            codigo: '$_id',
             // $reduce transforms the array of arrays into one flat unique array to count unique students
             amount_subject_students: {
               $size: {
                 $reduce: {
-                  input: '$allStudentsInGroup',
-                  initialValue: [],
                   in: { $setUnion: ['$$value', '$$this'] },
+                  initialValue: [],
+                  input: '$allStudentsInGroup',
                 },
               },
             },
+            codigo: '$_id',
             components: 1,
           },
         },
         { $sort: { amount_subject_students: -1 } },
       ]);
-      return reply.status(200).send({
-        status: 'success',
+      return await reply.status(200).send({
         data: requested,
+        status: 'success',
       });
     },
     method: 'GET',
@@ -231,8 +232,8 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       }),
       response: {
         200: z.object({
-          status: z.string(),
           data: z.any().array(),
+          status: z.string(),
         }),
       },
     },
@@ -247,7 +248,7 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       const cached =
         await request.redisService.getJSON<ListComponent[]>(cacheKey);
       if (cached) {
-        return reply.status(200).send(cached);
+        return await reply.status(200).send(cached);
       }
 
       const components = await ComponentModel.find({ season })
@@ -258,33 +259,29 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
       const mappedComponents = components.map(
         (component): ListComponent => ({
-          subject: component.subject?.name ?? '',
+          campus: component.campus,
           codigo: component.codigo ?? '',
+          disciplina_id: component.disciplina_id ?? null,
+          groupURL: component.groupURL ?? null,
+          identifier: component.identifier ?? null,
+          pratica: component.pratica?.name ?? null,
+          praticaId: component.pratica?._id?.toString() ?? null,
+          requisicoes: component.alunos_matriculados?.length ?? 0,
+          season: component.season,
+          subject: component.subject?.name ?? '',
+          subjectId: component.subject?._id?.toString() ?? '',
+          teoria: component.teoria?.name ?? null,
+          teoriaId: component.teoria?._id?.toString() ?? null,
           turma: component.turma,
           turno: component.turno,
-          vagas: component.vagas,
-          campus: component.campus,
-          season: component.season,
           uf_cod_turma: component.uf_cod_turma,
-          identifier: component.identifier ?? null,
-          disciplina_id: component.disciplina_id ?? null,
-          requisicoes: component.alunos_matriculados?.length ?? 0,
-          teoria: component.teoria?.name ?? null,
-          pratica: component.pratica?.name ?? null,
-          teoriaId: component.teoria?._id?.toString() ?? null,
-          praticaId: component.pratica?._id?.toString() ?? null,
-          groupURL: component.groupURL ?? null,
-          subjectId: component.subject?._id?.toString() ?? '',
+          vagas: component.vagas,
         })
       );
 
-      await request.redisService.setJSON(
-        cacheKey,
-        mappedComponents as ListComponent[],
-        '1h'
-      );
+      await request.redisService.setJSON(cacheKey, mappedComponents, '1h');
 
-      return reply.status(200).send(mappedComponents);
+      return await reply.status(200).send(mappedComponents);
     },
     method: 'GET',
     preHandler: [jwtVerifyHook],
@@ -313,10 +310,10 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       );
 
       if (!response) {
-        return reply.notFound('Component not found');
+        return await reply.notFound('Component not found');
       }
 
-      return reply.status(200).send(response);
+      return await reply.status(200).send(response);
     },
     method: 'GET',
     schema: {
@@ -346,21 +343,21 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
       const data = archives.map((archive) => ({
         _id: archive._id.toString(),
-        s3_key: archive.s3_key ?? null,
-        original_url: archive.original_url,
+        component: archive.component ?? null,
+        createdAt: archive.createdAt?.toISOString() ?? '',
         file_name: archive.file_name ?? null,
-        status: archive.status,
+        original_url: archive.original_url,
+        s3_key: archive.s3_key ?? null,
         source: archive.source,
+        status: archive.status,
         timeline: (archive.timeline ?? []).map((event) => ({
+          metadata: event.metadata as unknown,
           status: event.status,
           timestamp: event.timestamp?.toISOString() ?? '',
-          metadata: event.metadata,
         })),
-        createdAt: archive.createdAt?.toISOString() ?? '',
-        component: archive.component ?? null,
       }));
 
-      return await reply.status(200).send({ status: 'success', data });
+      return await reply.status(200).send({ data, status: 'success' });
     },
     method: 'GET',
     schema: {
@@ -369,8 +366,8 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       }),
       response: {
         200: z.object({
-          status: z.string(),
           data: z.array(z.any()),
+          status: z.string(),
         }),
       },
     },
@@ -384,8 +381,8 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       const archive = await ComponentArchiveModel.findById(archiveId);
       if (!archive || typeof archive.s3_key !== 'string') {
         return await reply.code(404).send({
-          status: 'error',
           message: 'Archive not found or not yet stored',
+          status: 'error',
         });
       }
 
@@ -399,8 +396,8 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
 
       if (!s3Object.Body) {
         return await reply.code(500).send({
-          status: 'error',
           message: 'Empty file on S3',
+          status: 'error',
         });
       }
 
@@ -412,13 +409,13 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
     method: 'GET',
     schema: {
       params: z.object({
-        componentId: z.string(),
         archiveId: z.string(),
+        componentId: z.string(),
       }),
       response: {
         200: z.any(),
-        404: z.object({ status: z.string(), message: z.string() }),
-        500: z.object({ status: z.string(), message: z.string() }),
+        404: z.object({ message: z.string(), status: z.string() }),
+        500: z.object({ message: z.string(), status: z.string() }),
       },
     },
     url: '/components/:componentId/archives/:archiveId/download',
@@ -436,22 +433,20 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
       const { userMessage } = request.body as { userMessage: string };
 
       let component: ComponentMetadata | null = null;
-      let response: any = null;
+      let response: unknown = null;
 
-      if (externalKey) {
+      if (externalKey !== undefined) {
         component = await ComponentMetadataModel.findOne({
           'metadata.component_data.componentKey': externalKey,
           'metadata.component_data.season': season,
         }).lean<ComponentMetadata>();
 
-        if (!component) {
-          component = await ComponentMetadataModel.findOne({
-            'metadata.component_data.componentKey': externalKey,
-          }).lean<ComponentMetadata>();
-        }
+        component ??= await ComponentMetadataModel.findOne({
+          'metadata.component_data.componentKey': externalKey,
+        }).lean<ComponentMetadata>();
 
-        if (!component) {
-          return reply.notFound('Component not found');
+        if (component === null) {
+          return await reply.notFound('Component not found');
         }
 
         response = await aiConnector.requestNaturalResponse(
@@ -460,9 +455,9 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         );
       }
 
-      return reply.status(200).send({
-        status: 'success',
+      return await reply.status(200).send({
         data: response,
+        status: 'success',
       });
     },
     method: 'POST',
@@ -472,13 +467,13 @@ const componentsController: FastifyPluginAsyncZod = async (app) => {
         userMessage: z.string(),
       }),
       querystring: z.object({
-        season: z.string().default('2026:2'),
         externalKey: z.string().optional(),
+        season: z.string().default('2026:2'),
       }),
       response: {
         200: z.object({
-          status: z.string(),
           data: z.any().optional(),
+          status: z.string(),
         }),
       },
     },

--- a/apps/core/src/errors/custom-errors.ts
+++ b/apps/core/src/errors/custom-errors.ts
@@ -1,0 +1,24 @@
+import { NextError } from './base-error.js';
+
+export class EmailVerificationFailed extends NextError {
+  constructor(description = 'Unable to verify user email') {
+    super('Email Verification Failed', 'NEX0001', 400, description);
+  }
+}
+
+export class UserWithoutRA extends NextError {
+  constructor() {
+    super(
+      'User Without RA',
+      'NEX0002',
+      403,
+      'User does not have an RA registered'
+    );
+  }
+}
+
+export class ArchiveParseFailed extends NextError {
+  constructor(description: string) {
+    super('Archive Parse Failed', 'NEX0003', 400, description);
+  }
+}

--- a/apps/core/src/errors/custom-errors.ts
+++ b/apps/core/src/errors/custom-errors.ts
@@ -22,3 +22,20 @@ export class ArchiveParseFailed extends NextError {
     super('Archive Parse Failed', 'NEX0003', 400, description);
   }
 }
+
+export class ArchiveNotFound extends NextError {
+  constructor() {
+    super(
+      'Archive Not Found',
+      'NEX0004',
+      404,
+      'Archive not found or not yet stored'
+    );
+  }
+}
+
+export class ArchiveFileEmpty extends NextError {
+  constructor() {
+    super('Archive File Empty', 'NEX0005', 500, 'Empty file on S3');
+  }
+}

--- a/apps/core/src/hooks/moodle-session.ts
+++ b/apps/core/src/hooks/moodle-session.ts
@@ -18,6 +18,15 @@ export type Session = {
   sessKey: string;
 };
 
+export function isSession(value: unknown): value is Session {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'sessionId' in value &&
+    'sessKey' in value
+  );
+}
+
 const sessionCache = new LRUWeakCache<{ sessionId: string }>({
   capacity: 5000,
   maxAge: 1000 * 60 * 5,

--- a/apps/core/src/hooks/moodle-session.ts
+++ b/apps/core/src/hooks/moodle-session.ts
@@ -1,10 +1,10 @@
 import type { preHandlerAsyncHookHandler } from 'fastify';
-
 import LRUWeakCache from 'lru-weak-cache';
 
 import { MoodleConnector } from '@/connectors/moodle.js';
 
 declare module '@fastify/request-context' {
+  // oxlint-disable-next-line typescript/consistent-type-definitions
   interface RequestContextData {
     moodleSession: {
       sessionId: string;
@@ -23,45 +23,6 @@ const sessionCache = new LRUWeakCache<{ sessionId: string }>({
   maxAge: 1000 * 60 * 5,
 });
 
-export const moodleSession: preHandlerAsyncHookHandler = async (
-  request,
-  reply
-) => {
-  const { 'session-id': sessionId, 'sess-key': sessKey } = request.headers;
-
-  if (
-    !sessionId ||
-    !sessKey ||
-    typeof sessionId !== 'string' ||
-    typeof sessKey !== 'string'
-  ) {
-    // should never happen, cause the schema validation runs before this hook
-    return reply.unauthorized('Missing Session');
-  }
-
-  if (sessionCache.has(sessionId)) {
-    request.log.debug({ sessionId }, 'Session found in cache');
-    request.requestContext.set('moodleSession', {
-      sessionId,
-      sessKey,
-    });
-    return;
-  }
-
-  const isTokenValid = await validateToken(sessionId, sessKey);
-  request.log.debug({ isTokenValid }, 'Token validated');
-  if (!isTokenValid) {
-    return reply.forbidden('Invalid Session');
-  }
-  request.log.debug({ sessionId }, 'Session validated');
-
-  sessionCache.set(sessionId, { sessionId });
-  request.requestContext.set('moodleSession', {
-    sessionId,
-    sessKey,
-  });
-};
-
 async function validateToken(sessionId: string, sessKey: string) {
   const connector = new MoodleConnector();
   const response = await connector.validateToken(sessionId, sessKey);
@@ -74,3 +35,38 @@ async function validateToken(sessionId: string, sessKey: string) {
 
   return true;
 }
+
+export const moodleSession: preHandlerAsyncHookHandler = async (
+  request,
+  reply
+) => {
+  const { 'session-id': sessionId, 'sess-key': sessKey } = request.headers;
+
+  if (typeof sessionId !== 'string' || typeof sessKey !== 'string') {
+    // should never happen, cause the schema validation runs before this hook
+    return await reply.unauthorized('Missing Session');
+  }
+
+  if (sessionCache.has(sessionId)) {
+    request.log.debug({ sessionId }, 'Session found in cache');
+    request.requestContext.set('moodleSession', {
+      sessKey,
+      sessionId,
+    });
+    return;
+  }
+
+  const isTokenValid = await validateToken(sessionId, sessKey);
+  request.log.debug({ isTokenValid }, 'Token validated');
+  if (!isTokenValid) {
+    return await reply.forbidden('Invalid Session');
+  }
+  request.log.debug({ sessionId }, 'Session validated');
+
+  sessionCache.set(sessionId, { sessionId });
+  request.requestContext.set('moodleSession', {
+    sessKey,
+    sessionId,
+  });
+  return;
+};

--- a/apps/core/src/jobs/components-archive-processing-flow.ts
+++ b/apps/core/src/jobs/components-archive-processing-flow.ts
@@ -1,17 +1,17 @@
 import { defineJob } from '@next/queues/client';
-import { load } from 'cheerio';
-import { ofetch } from 'ofetch';
 import z from 'zod';
 
-import { MoodleConnector } from '@/connectors/moodle.js';
 import { JOB_NAMES } from '@/constants.js';
-
-const connector = new MoodleConnector();
+import { ComponentArchiveModel } from '@/models/ComponentArchive.js';
+import { ArchiveEngine } from '@/services/archive-engine.js';
 
 const componentSchema = z.object({
   viewurl: z.string().url(),
   fullname: z.string(),
+  shortname: z.string().optional(),
+  idnumber: z.string().optional(),
   id: z.number(),
+  startdate: z.number().optional(),
 });
 
 export const componentsArchivesProcessingJob = defineJob(
@@ -25,26 +25,37 @@ export const componentsArchivesProcessingJob = defineJob(
         sessionId: z.string(),
         sessKey: z.string(),
       }),
+      enrolledCodigos: z.array(z.string()).optional(),
     })
   )
   .iterator('component')
   .concurrency(3)
-  .handler(async ({ job, app, manager }) => {
-    const { component, session } = job.data;
+  .handler(async ({ job, manager }) => {
+    const { component, session, enrolledCodigos } = job.data;
     const globalTraceId = job.data.globalTraceId;
 
-    const pdfs = await extractPDFsFromComponent(
-      component.viewurl,
-      session.sessionId,
-      component.id,
-      session.sessKey
+    const engine = new ArchiveEngine({ globalTraceId, session });
+
+    const teacherNames = await engine.extractTeacherNames(component.id);
+
+    const matchedComponent = await engine.findComponentByMoodleCourse(
+      component,
+      teacherNames,
+      enrolledCodigos
     );
 
-    if (pdfs.length === 0) {
-      app.log.info(
-        { globalTraceId, component: component.fullname },
-        'No PDFs found in component'
+    if (!matchedComponent) {
+      throw new Error(
+        `No matching component found for Moodle course: "${component.fullname}" (id: ${component.id}). ` +
+          `Could not find a matching component in the system.`
       );
+    }
+
+    const componentDbId = matchedComponent._id.toString();
+
+    const files = await engine.extractFiles(component.viewurl, component.id);
+
+    if (files.length === 0) {
       return {
         success: true,
         message: 'No PDFs found in component',
@@ -55,15 +66,16 @@ export const componentsArchivesProcessingJob = defineJob(
     await manager.dispatchFlow({
       name: `summary-${component.fullname}`,
       queueName: JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING_SUMMARY,
-      data: { name: component.fullname, total: pdfs.length, globalTraceId },
-      children: pdfs.map((pdf) => ({
+      data: { name: component.fullname, total: files.length, globalTraceId },
+      children: files.map((file) => ({
         name: JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING_PDF,
         queueName: JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING_PDF,
         data: {
           component: component.fullname,
-          rawUrl: pdf.pdfLink,
-          moodleComponentId: component.id,
+          rawUrl: file.url,
+          componentDbId,
           globalTraceId,
+          session,
         },
       })),
     });
@@ -71,6 +83,8 @@ export const componentsArchivesProcessingJob = defineJob(
     return {
       success: true,
       flowStarted: true,
+      componentDbId,
+      moodleCourseId: component.id,
     };
   });
 
@@ -81,41 +95,75 @@ export const pdfDownloadJob = defineJob(
     z.object({
       component: z.string(),
       rawUrl: z.string().url(),
-      moodleComponentId: z.number(),
+      componentDbId: z.string(),
       globalTraceId: z.string().optional(),
+      session: z
+        .object({
+          sessionId: z.string(),
+          sessKey: z.string(),
+        })
+        .optional(),
     })
   )
   .concurrency(10)
   .handler(async ({ job, app }) => {
-    const { rawUrl, moodleComponentId } = job.data;
-    // Represents nothing currently.
-    // const filteredFiles = await aiProxyConnector.filterFiles(component, [
-    //   { url, name: `${component}.pdf` },
-    // ]);
+    const { rawUrl, componentDbId, globalTraceId, session } = job.data;
 
-    const url = new URL(rawUrl);
-    const buffer = await ofetch(url.href, { responseType: 'arrayBuffer' });
+    const engine = new ArchiveEngine({
+      globalTraceId,
+      session,
+      s3Connector: app.aws.s3,
+    });
 
-    // Extract filename from URL pathname and decode it
-    const filenameFromUrl = extractFilenameFromUrl(url);
-    const sanitizedFilename = sanitizeFilename(filenameFromUrl);
-    const s3Key = `/archives/${moodleComponentId}/${sanitizedFilename}`;
-
-    await app.aws.s3.upload(
-      app.config.AWS_BUCKET ?? '',
-      s3Key,
-      Buffer.from(buffer)
+    const archive = await ComponentArchiveModel.findOneAndUpdate(
+      { component: componentDbId, original_url: rawUrl },
+      {
+        $setOnInsert: {
+          component: componentDbId,
+          original_url: rawUrl,
+          timeline: [{ status: 'created', metadata: { globalTraceId } }],
+        },
+        $set: { status: 'created' },
+      },
+      { upsert: true, new: true }
     );
 
-    return {
-      success: true,
-      message: 'PDF uploaded',
-      data: {
-        pdfLink: url.href,
-        pdfName: sanitizedFilename,
-        s3Key,
-      },
-    };
+    try {
+      const { pdfName, s3Key } = await engine.downloadAndUpload(
+        rawUrl,
+        componentDbId,
+        app.config.AWS_BUCKET
+      );
+
+      await ComponentArchiveModel.findByIdAndUpdate(archive._id, {
+        $set: {
+          s3_key: s3Key,
+          file_name: pdfName,
+          status: 'stored',
+        },
+        $push: {
+          timeline: { status: 'stored' },
+        },
+      });
+
+      return {
+        success: true,
+        message: 'PDF uploaded',
+        data: {
+          fileName: pdfName,
+          s3Key,
+        },
+        archiveId: archive._id,
+      };
+    } catch (error) {
+      await ComponentArchiveModel.findByIdAndUpdate(archive._id, {
+        $push: {
+          timeline: { status: 'failed', metadata: { error: String(error) } },
+        },
+        $set: { status: 'failed' },
+      });
+      throw error;
+    }
   });
 
 export const archivesSummaryJob = defineJob(
@@ -128,7 +176,7 @@ export const archivesSummaryJob = defineJob(
       globalTraceId: z.string().optional(),
     })
   )
-  .handler(async ({ job, app }) => {
+  .handler(async ({ job }) => {
     const { name, total, globalTraceId } = job.data;
     return {
       success: true,
@@ -136,116 +184,3 @@ export const archivesSummaryJob = defineJob(
       data: { name, total, globalTraceId },
     };
   });
-
-async function extractPDFsFromComponent(
-  viewurl: string,
-  sessionId: string,
-  componentId: number,
-  sessionKey: string
-) {
-  const url = new URL(viewurl);
-  const page = await connector.getComponentContentsPage(
-    sessionId,
-    url.pathname,
-    componentId.toString()
-  );
-  const $ = load(page);
-  const potentialLinks: { href: string; name: string }[] = [];
-
-  $('div.activityname').each((_index, el) => {
-    const href = $(el).find('a').attr('href');
-    const name = $(el).find('span.instancename').text();
-    if (href && name) {
-      potentialLinks.push({ href, name });
-    }
-  });
-
-  $('a[href*="/mod/resource/"]').each((_index, el) => {
-    const link = $(el).attr('href');
-    const name = $(el).text().trim();
-    if (link && name && !potentialLinks.some((p) => p.href === link)) {
-      potentialLinks.push({ href: link, name });
-    }
-  });
-
-  $('a[href*="/pluginfile.php/"]').each((_index, el) => {
-    const link = $(el).attr('href');
-    const name = $(el).text().trim() || $(el).attr('title') || 'documento';
-    if (link?.toLowerCase()?.endsWith('.pdf')) {
-      if (!potentialLinks.some((p) => p.href === link)) {
-        potentialLinks.push({ href: link, name });
-      }
-    }
-  });
-
-  const validationPromises = potentialLinks.map(async ({ href, name }) => {
-    const { isPdf, finalUrl } = await connector.validatePdfLink(
-      href,
-      sessionId,
-      sessionKey
-    );
-
-    if (!isPdf) {
-      return null;
-    }
-
-    if (finalUrl) {
-      return { pdfLink: finalUrl, pdfName: name };
-    }
-    return null;
-  });
-
-  const validatedLinks = await Promise.all(validationPromises);
-  return validatedLinks.filter((link) => link !== null);
-}
-
-function extractFilenameFromUrl(url: URL): string {
-  const pathname = url.pathname;
-  const segments = pathname.split('/').filter((segment) => segment.length > 0);
-  const lastSegment = segments[segments.length - 1] || 'document.pdf';
-
-  try {
-    return decodeURIComponent(lastSegment);
-  } catch {
-    return lastSegment;
-  }
-}
-
-/**
- * Sanitizes a filename for S3 upload by:
- * - Removing invalid characters
- * - Ensuring it ends with .pdf
- * - Replacing spaces and special chars with underscores
- */
-function sanitizeFilename(filename: string): string {
-  // Remove invalid S3 characters: < > : " | ? * and control characters
-  const invalidChars = /[<>:"|?*\s]/g;
-
-  let sanitized = filename
-    .split('')
-    .map((char) => {
-      const code = char.charCodeAt(0);
-      // Check for invalid S3 chars or control characters (0-31)
-      if (invalidChars.test(char) || (code >= 0 && code <= 31)) {
-        return '_';
-      }
-      return char;
-    })
-    .join('')
-    .replace(/_{2,}/g, '_')
-    .trim();
-
-  // Ensure it ends with .pdf
-  if (!sanitized.toLowerCase().endsWith('.pdf')) {
-    sanitized = `${sanitized}.pdf`;
-  }
-
-  // Limit length (S3 key limit is 1024 chars, but keep reasonable)
-  if (sanitized.length > 255) {
-    const ext = '.pdf';
-    const nameWithoutExt = sanitized.slice(0, 255 - ext.length);
-    sanitized = `${nameWithoutExt}${ext}`;
-  }
-
-  return sanitized || 'document.pdf';
-}

--- a/apps/core/src/jobs/components-archive-processing-flow.ts
+++ b/apps/core/src/jobs/components-archive-processing-flow.ts
@@ -129,17 +129,30 @@ export const pdfDownloadJob = defineJob(
     );
 
     try {
-      const { pdfName, s3Key } = await engine.downloadAndUpload(
+      const { checksum, pdfName, s3Key } = await engine.downloadAndUpload(
         rawUrl,
         componentDbId,
         app.config.AWS_BUCKET
       );
+
+      if (archive.checksum === checksum) {
+        return {
+          archiveId: archive._id,
+          data: {
+            fileName: archive.file_name,
+            s3Key: archive.s3_key,
+          },
+          message: 'PDF unchanged since last run, skipping stored event',
+          success: true,
+        };
+      }
 
       await ComponentArchiveModel.findByIdAndUpdate(archive._id, {
         $push: {
           timeline: { status: 'stored' },
         },
         $set: {
+          checksum,
           file_name: pdfName,
           s3_key: s3Key,
           status: 'stored',

--- a/apps/core/src/jobs/components-archive-processing-flow.ts
+++ b/apps/core/src/jobs/components-archive-processing-flow.ts
@@ -6,12 +6,12 @@ import { ComponentArchiveModel } from '@/models/ComponentArchive.js';
 import { ArchiveEngine } from '@/services/archive-engine.js';
 
 const componentSchema = z.object({
-  viewurl: z.string().url(),
   fullname: z.string(),
-  shortname: z.string().optional(),
-  idnumber: z.string().optional(),
   id: z.number(),
+  idnumber: z.string().optional(),
+  shortname: z.string().optional(),
   startdate: z.number().optional(),
+  viewurl: z.string().url(),
 });
 
 export const componentsArchivesProcessingJob = defineJob(
@@ -20,19 +20,19 @@ export const componentsArchivesProcessingJob = defineJob(
   .input(
     z.object({
       component: componentSchema.array(),
+      enrolledCodigos: z.array(z.string()).optional(),
       globalTraceId: z.string().optional(),
       session: z.object({
-        sessionId: z.string(),
         sessKey: z.string(),
+        sessionId: z.string(),
       }),
-      enrolledCodigos: z.array(z.string()).optional(),
     })
   )
   .iterator('component')
   .concurrency(3)
   .handler(async ({ job, manager }) => {
     const { component, session, enrolledCodigos } = job.data;
-    const globalTraceId = job.data.globalTraceId;
+    const { globalTraceId } = job.data;
 
     const engine = new ArchiveEngine({ globalTraceId, session });
 
@@ -57,34 +57,34 @@ export const componentsArchivesProcessingJob = defineJob(
 
     if (files.length === 0) {
       return {
-        success: true,
-        message: 'No PDFs found in component',
         data: [],
+        message: 'No PDFs found in component',
+        success: true,
       };
     }
 
     await manager.dispatchFlow({
-      name: `summary-${component.fullname}`,
-      queueName: JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING_SUMMARY,
-      data: { name: component.fullname, total: files.length, globalTraceId },
       children: files.map((file) => ({
-        name: JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING_PDF,
-        queueName: JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING_PDF,
         data: {
           component: component.fullname,
-          rawUrl: file.url,
           componentDbId,
           globalTraceId,
+          rawUrl: file.url,
           session,
         },
+        name: JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING_PDF,
+        queueName: JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING_PDF,
       })),
+      data: { globalTraceId, name: component.fullname, total: files.length },
+      name: `summary-${component.fullname}`,
+      queueName: JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING_SUMMARY,
     });
 
     return {
-      success: true,
-      flowStarted: true,
       componentDbId,
+      flowStarted: true,
       moodleCourseId: component.id,
+      success: true,
     };
   });
 
@@ -94,13 +94,13 @@ export const pdfDownloadJob = defineJob(
   .input(
     z.object({
       component: z.string(),
-      rawUrl: z.string().url(),
       componentDbId: z.string(),
       globalTraceId: z.string().optional(),
+      rawUrl: z.string().url(),
       session: z
         .object({
-          sessionId: z.string(),
           sessKey: z.string(),
+          sessionId: z.string(),
         })
         .optional(),
     })
@@ -111,21 +111,21 @@ export const pdfDownloadJob = defineJob(
 
     const engine = new ArchiveEngine({
       globalTraceId,
-      session,
       s3Connector: app.aws.s3,
+      session,
     });
 
     const archive = await ComponentArchiveModel.findOneAndUpdate(
       { component: componentDbId, original_url: rawUrl },
       {
+        $set: { status: 'created' },
         $setOnInsert: {
           component: componentDbId,
           original_url: rawUrl,
-          timeline: [{ status: 'created', metadata: { globalTraceId } }],
+          timeline: [{ metadata: { globalTraceId }, status: 'created' }],
         },
-        $set: { status: 'created' },
       },
-      { upsert: true, new: true }
+      { new: true, upsert: true }
     );
 
     try {
@@ -136,29 +136,29 @@ export const pdfDownloadJob = defineJob(
       );
 
       await ComponentArchiveModel.findByIdAndUpdate(archive._id, {
-        $set: {
-          s3_key: s3Key,
-          file_name: pdfName,
-          status: 'stored',
-        },
         $push: {
           timeline: { status: 'stored' },
+        },
+        $set: {
+          file_name: pdfName,
+          s3_key: s3Key,
+          status: 'stored',
         },
       });
 
       return {
-        success: true,
-        message: 'PDF uploaded',
+        archiveId: archive._id,
         data: {
           fileName: pdfName,
           s3Key,
         },
-        archiveId: archive._id,
+        message: 'PDF uploaded',
+        success: true,
       };
     } catch (error) {
       await ComponentArchiveModel.findByIdAndUpdate(archive._id, {
         $push: {
-          timeline: { status: 'failed', metadata: { error: String(error) } },
+          timeline: { metadata: { error: String(error) }, status: 'failed' },
         },
         $set: { status: 'failed' },
       });
@@ -171,16 +171,16 @@ export const archivesSummaryJob = defineJob(
 )
   .input(
     z.object({
+      globalTraceId: z.string().optional(),
       name: z.string(),
       total: z.number(),
-      globalTraceId: z.string().optional(),
     })
   )
   .handler(async ({ job }) => {
     const { name, total, globalTraceId } = job.data;
     return {
-      success: true,
+      data: { globalTraceId, name, total },
       message: 'Archives summary',
-      data: { name, total, globalTraceId },
+      success: true,
     };
   });

--- a/apps/core/src/jobs/components-archive-processing-flow.ts
+++ b/apps/core/src/jobs/components-archive-processing-flow.ts
@@ -176,7 +176,7 @@ export const archivesSummaryJob = defineJob(
       total: z.number(),
     })
   )
-  .handler(async ({ job }) => {
+  .handler(({ job }) => {
     const { name, total, globalTraceId } = job.data;
     return {
       data: { globalTraceId, name, total },

--- a/apps/core/src/jobs/components-processing.ts
+++ b/apps/core/src/jobs/components-processing.ts
@@ -1,62 +1,13 @@
 import { defineJob } from '@next/queues/client';
-import type { Types } from 'mongoose';
 import z from 'zod';
 
 import { UfabcParserConnector } from '@/connectors/ufabc-parser.js';
 import { JOB_NAMES, PARSER_WEBHOOK_SUPPORTED_EVENTS } from '@/constants.js';
 import { ComponentModel } from '@/models/Component.js';
-import {
-  TeacherModel,
-  findBestLevenshteinMatch,
-  normalizeName,
-} from '@/models/Teacher.js';
+import { findTeacher } from '@/models/Teacher.js';
 import { ComponentSateSchema } from '@/schemas/v2/webhook/ufabc-parser.js';
 
 import { findOrCreateSubject } from './utils/subject-resolution.js';
-
-const teacherCache = new Map<string, Types.ObjectId | null>();
-
-async function findTeacher(
-  name: string | null
-): Promise<Types.ObjectId | null> {
-  if (!name) {
-    return null;
-  }
-
-  const normalizedName = normalizeName(name);
-
-  if (teacherCache.has(normalizedName)) {
-    return teacherCache.get(normalizedName)!;
-  }
-
-  const teacher = await TeacherModel.findOne({ name: normalizedName });
-  if (!teacher) {
-    const allTeachers = await TeacherModel.find({});
-    const levMatch = findBestLevenshteinMatch(name, allTeachers);
-    if (levMatch) {
-      await TeacherModel.findByIdAndUpdate(levMatch._id, {
-        $addToSet: { alias: { $each: [normalizedName, name.toLowerCase()] } },
-      });
-      teacherCache.set(normalizedName, levMatch._id);
-      return levMatch._id;
-    }
-  }
-
-  if (!teacher && normalizedName !== '0') {
-    teacherCache.set(normalizedName, null);
-    return null;
-  }
-
-  if (teacher && !teacher.alias.includes(normalizedName)) {
-    await TeacherModel.findByIdAndUpdate(teacher._id, {
-      $addToSet: { alias: { $each: [normalizedName, name.toLowerCase()] } },
-    });
-  }
-
-  const teacherId = teacher?._id ?? null;
-  teacherCache.set(normalizedName, teacherId);
-  return teacherId;
-}
 
 export const createComponentJob = defineJob(JOB_NAMES.COMPONENTS_PROCESSING)
   .input(

--- a/apps/core/src/mappers/component-archive-mapper.ts
+++ b/apps/core/src/mappers/component-archive-mapper.ts
@@ -1,0 +1,28 @@
+import type { Types } from 'mongoose';
+
+import type { ComponentArchive } from '@/models/ComponentArchive.js';
+
+type LeanComponentArchive = ComponentArchive & {
+  _id: Types.ObjectId;
+  createdAt?: Date;
+};
+
+export class ComponentArchiveMapper {
+  toResponse(archive: LeanComponentArchive) {
+    return {
+      _id: archive._id.toString(),
+      component: archive.component ?? null,
+      createdAt: archive.createdAt?.toISOString() ?? '',
+      file_name: archive.file_name ?? null,
+      original_url: archive.original_url,
+      s3_key: archive.s3_key ?? null,
+      source: archive.source,
+      status: archive.status,
+      timeline: (archive.timeline ?? []).map((event) => ({
+        metadata: event.metadata as unknown,
+        status: event.status,
+        timestamp: event.timestamp?.toISOString() ?? '',
+      })),
+    };
+  }
+}

--- a/apps/core/src/mappers/component-archive-mapper.ts
+++ b/apps/core/src/mappers/component-archive-mapper.ts
@@ -1,11 +1,4 @@
-import type { Types } from 'mongoose';
-
-import type { ComponentArchive } from '@/models/ComponentArchive.js';
-
-type LeanComponentArchive = ComponentArchive & {
-  _id: Types.ObjectId;
-  createdAt?: Date;
-};
+import type { LeanComponentArchive } from '@/repositories/component-archives-repository.js';
 
 export class ComponentArchiveMapper {
   toResponse(archive: LeanComponentArchive) {

--- a/apps/core/src/models/Component.ts
+++ b/apps/core/src/models/Component.ts
@@ -32,6 +32,11 @@ const componentSchema = new Schema(
       required: false,
       default: null,
     },
+    moodleCourseId: {
+      type: Number,
+      sparse: true,
+      default: null,
+    },
     // lista de alunos matriculados no momento
     alunos_matriculados: {
       type: [Number],

--- a/apps/core/src/models/ComponentArchive.ts
+++ b/apps/core/src/models/ComponentArchive.ts
@@ -31,6 +31,7 @@ const componentArchiveSchema = new Schema(
     s3_key: { type: String },
     original_url: { type: String, required: true },
     file_name: { type: String },
+    checksum: { type: String },
     source: {
       type: String,
       enum: ['moodle', 'manual', 'sigaa'],

--- a/apps/core/src/models/ComponentArchive.ts
+++ b/apps/core/src/models/ComponentArchive.ts
@@ -1,0 +1,65 @@
+import { type InferSchemaType, Schema, model } from 'mongoose';
+
+const COMPONENT_ARCHIVE_STATUS = [
+  'created',
+  'downloaded',
+  'stored',
+  'failed',
+  'deleted',
+] as const;
+
+const timelineEventSchema = new Schema(
+  {
+    status: {
+      type: String,
+      enum: COMPONENT_ARCHIVE_STATUS,
+      required: true,
+    },
+    timestamp: { type: Date, default: Date.now, required: true },
+    metadata: { type: Schema.Types.Mixed },
+  },
+  { _id: false }
+);
+
+const componentArchiveSchema = new Schema(
+  {
+    component: {
+      type: Schema.Types.ObjectId,
+      ref: 'disciplinas',
+      required: true,
+    },
+    s3_key: { type: String },
+    original_url: { type: String, required: true },
+    file_name: { type: String },
+    source: {
+      type: String,
+      enum: ['moodle', 'manual', 'sigaa'],
+      required: true,
+      default: 'moodle',
+    },
+    status: {
+      type: String,
+      enum: COMPONENT_ARCHIVE_STATUS,
+      default: 'created',
+      required: true,
+    },
+    timeline: { type: [timelineEventSchema], default: [] },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: false },
+    versionKey: false,
+  }
+);
+
+componentArchiveSchema.index({ component: 1, status: 1 });
+componentArchiveSchema.index(
+  { component: 1, original_url: 1 },
+  { unique: true }
+);
+
+export type ComponentArchive = InferSchemaType<typeof componentArchiveSchema>;
+
+export const ComponentArchiveModel = model(
+  'component_archives',
+  componentArchiveSchema
+);

--- a/apps/core/src/models/Teacher.ts
+++ b/apps/core/src/models/Teacher.ts
@@ -1,4 +1,4 @@
-import { type InferSchemaType, Schema, model } from 'mongoose';
+import { type InferSchemaType, Schema, model, Types } from 'mongoose';
 
 export function normalizeName(str: string): string {
   return str
@@ -97,6 +97,53 @@ teacherSchema.index(
   { externalKey: 1 },
   { unique: true, name: 'TeacherExternalKeyIndex', sparse: true }
 );
+
+const teacherCache = new Map<string, Types.ObjectId | null>();
+
+export async function findTeacher(
+  name: string | null
+): Promise<Types.ObjectId | null> {
+  if (!name) return null;
+
+  const normalizedName = normalizeName(name);
+
+  if (teacherCache.has(normalizedName)) {
+    return teacherCache.get(normalizedName)!;
+  }
+
+  const teacher = await TeacherModel.findOne({ name: normalizedName });
+
+  if (!teacher) {
+    const allTeachers = await TeacherModel.find({});
+    const levMatch = findBestLevenshteinMatch(name, allTeachers);
+    if (levMatch) {
+      await TeacherModel.findByIdAndUpdate(levMatch._id, {
+        $addToSet: { alias: { $each: [normalizedName, name.toLowerCase()] } },
+      });
+      teacherCache.set(normalizedName, levMatch._id);
+      return levMatch._id;
+    }
+  }
+
+  if (!teacher && normalizedName !== '0') {
+    teacherCache.set(normalizedName, null);
+    return null;
+  }
+
+  if (teacher && !teacher.alias.includes(normalizedName)) {
+    await TeacherModel.findByIdAndUpdate(teacher._id, {
+      $addToSet: { alias: { $each: [normalizedName, name.toLowerCase()] } },
+    });
+  }
+
+  const teacherId = teacher?._id ?? null;
+  teacherCache.set(normalizedName, teacherId);
+  return teacherId;
+}
+
+export function clearTeacherCache() {
+  teacherCache.clear();
+}
 
 export type Teacher = InferSchemaType<typeof teacherSchema>;
 export type TeacherDocument = ReturnType<(typeof TeacherModel)['hydrate']>;

--- a/apps/core/src/plugins/external/request-context.ts
+++ b/apps/core/src/plugins/external/request-context.ts
@@ -1,10 +1,9 @@
-import type { FastifyInstance } from 'fastify';
-
 import { fastifyRequestContext } from '@fastify/request-context';
+import type { FastifyInstance } from 'fastify';
 import { fastifyPlugin as fp } from 'fastify-plugin';
 
 export default fp(
-  async function requestContextPlugin(app: FastifyInstance) {
+  async (app: FastifyInstance) => {
     await app.register(fastifyRequestContext);
   },
   { name: 'request-context' }

--- a/apps/core/src/repositories/base-repository.ts
+++ b/apps/core/src/repositories/base-repository.ts
@@ -1,0 +1,17 @@
+import { logger as defaultLogger } from '@/utils/logger.js';
+
+export type BaseRepositoryOptions = {
+  globalTraceId?: string;
+};
+
+export abstract class BaseRepository {
+  protected readonly logger: ReturnType<typeof defaultLogger.child>;
+
+  constructor({ globalTraceId }: BaseRepositoryOptions = {}) {
+    this.logger = defaultLogger.child({
+      component: this.constructor.name,
+      globalTraceId,
+      module: 'repositories',
+    });
+  }
+}

--- a/apps/core/src/repositories/component-archives-repository.ts
+++ b/apps/core/src/repositories/component-archives-repository.ts
@@ -1,0 +1,43 @@
+import type { Types } from 'mongoose';
+
+import { ComponentArchiveModel } from '@/models/ComponentArchive.js';
+import type { ComponentArchive } from '@/models/ComponentArchive.js';
+
+import { BaseRepository } from './base-repository.js';
+import type { BaseRepositoryOptions } from './base-repository.js';
+
+export type LeanComponentArchive = ComponentArchive & {
+  _id: Types.ObjectId;
+  createdAt?: Date;
+};
+
+export type ComponentArchivesRepositoryOptions = BaseRepositoryOptions & {
+  model?: typeof ComponentArchiveModel;
+};
+
+export class ComponentArchivesRepository extends BaseRepository {
+  private readonly model: typeof ComponentArchiveModel;
+
+  constructor({ model, ...options }: ComponentArchivesRepositoryOptions = {}) {
+    super(options);
+    this.model = model ?? ComponentArchiveModel;
+  }
+
+  async findByComponentId(
+    componentId: string
+  ): Promise<LeanComponentArchive[]> {
+    this.logger.debug({ componentId }, 'Listing archives by component');
+
+    return await this.model
+      .find({ component: componentId })
+      .populate('component', 'disciplina codigo turma turno season')
+      .sort({ createdAt: -1 })
+      .lean();
+  }
+
+  async findById(archiveId: string) {
+    this.logger.debug({ archiveId }, 'Finding archive by id');
+
+    return await this.model.findById(archiveId);
+  }
+}

--- a/apps/core/src/repositories/components-repository.ts
+++ b/apps/core/src/repositories/components-repository.ts
@@ -1,0 +1,93 @@
+import type { Types } from 'mongoose';
+
+import { ComponentModel } from '@/models/Component.js';
+import type { ComponentDocument } from '@/models/Component.js';
+
+import { BaseRepository } from './base-repository.js';
+import type { BaseRepositoryOptions } from './base-repository.js';
+
+const ACCENT_MAP: Record<string, string> = {
+  a: '[aáàâãAÁÀÂÃ]',
+  c: '[cçCÇ]',
+  e: '[eéêEÉÊ]',
+  i: '[iíIÍ]',
+  o: '[oóôõOÓÔÕ]',
+  u: '[uúüUÚÜ]',
+};
+
+function buildAccentInsensitiveRegex(word: string): string {
+  let pattern = '';
+  for (const char of word.toLowerCase()) {
+    pattern += ACCENT_MAP[char] ?? char;
+  }
+  return pattern;
+}
+
+// most recent season first, so archive matching prefers the latest offering
+const MOST_RECENT_SEASON_FIRST = { quad: -1 as const, year: -1 as const };
+
+export type ComponentsRepositoryOptions = BaseRepositoryOptions & {
+  model?: typeof ComponentModel;
+};
+
+export class ComponentsRepository extends BaseRepository {
+  private readonly model: typeof ComponentModel;
+
+  constructor({ model, ...options }: ComponentsRepositoryOptions = {}) {
+    super(options);
+    this.model = model ?? ComponentModel;
+  }
+
+  async findByCodigo(
+    codigo: string,
+    filter: Record<string, unknown> = {}
+  ): Promise<ComponentDocument | null> {
+    this.logger.debug({ codigo, filter }, 'Finding component by codigo');
+
+    return await this.model
+      .findOne({
+        codigo,
+        ...filter,
+      })
+      .sort(MOST_RECENT_SEASON_FIRST);
+  }
+
+  async findByDisciplinaKeywords(
+    keywords: string[],
+    filter: Record<string, unknown> = {}
+  ): Promise<ComponentDocument | null> {
+    if (keywords.length === 0) {
+      return null;
+    }
+
+    this.logger.debug(
+      { filter, keywords },
+      'Finding component by disciplina keywords'
+    );
+
+    const regexConditions = keywords.map((keyword) => ({
+      disciplina: { $regex: buildAccentInsensitiveRegex(keyword) },
+    }));
+
+    return await this.model
+      .findOne({
+        $and: regexConditions,
+        ...filter,
+      })
+      .sort(MOST_RECENT_SEASON_FIRST);
+  }
+
+  async setMoodleCourseId(
+    componentId: Types.ObjectId,
+    moodleCourseId: number
+  ): Promise<void> {
+    this.logger.debug(
+      { componentId, moodleCourseId },
+      'Setting moodleCourseId on component'
+    );
+
+    await this.model.findByIdAndUpdate(componentId, {
+      $set: { moodleCourseId },
+    });
+  }
+}

--- a/apps/core/src/schemas/v2/components.ts
+++ b/apps/core/src/schemas/v2/components.ts
@@ -7,7 +7,10 @@ export const componentArchiveSchema = z
   .object({
     viewurl: z.string().url(),
     fullname: z.string(),
+    shortname: z.string().optional(),
+    idnumber: z.string().optional(),
     id: z.number(),
+    startdate: z.number().optional(),
   })
   .array();
 

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -104,7 +104,7 @@ export class ArchiveEngine {
     s3Connector?: S3Connector;
   } = {}) {
     this.logger = baseLogger.child({ globalTraceId });
-    this.moodleConnector = new MoodleConnector(globalTraceId);
+    this.moodleConnector = new MoodleConnector({ globalTraceId });
     this.session = session;
     this.s3Connector = s3Connector;
   }
@@ -376,6 +376,16 @@ export class ArchiveEngine {
       'No matching component found'
     );
     return null;
+  }
+
+  async getUserEmail(sessionId: string): Promise<string | null> {
+    const userPage = await this.moodleConnector.getUserPage(sessionId);
+    const $ = load(userPage);
+    const email = $(
+      '#region-main > div > div > div.userprofile > div > section:nth-child(1) > div > ul > li:nth-child(2) > dl > dd > a'
+    ).text();
+
+    return email || null;
   }
 
   async fetchAndValidateCourses(session: MoodleSession) {

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -1,3 +1,4 @@
+import { findArchiveQuarter } from '@next/utils';
 import { load } from 'cheerio';
 import { ofetch } from 'ofetch';
 
@@ -64,13 +65,15 @@ export class ArchiveEngine {
     }
 
     if (moodleCourse.shortname != null) {
-      const codeMatch = /[A-Z]{2,}\d{3,}(?:-\d+)?/.exec(moodleCourse.shortname);
+      const codeMatch = /[A-Z]{2,}\d{3,}(?:-\d+)?/u.exec(
+        moodleCourse.shortname
+      );
       if (codeMatch) {
         candidates.push(codeMatch[0]);
       }
     }
 
-    const codeMatch = /[A-Z]{2,}\d{3,}(?:-\d+)?/.exec(moodleCourse.fullname);
+    const codeMatch = /[A-Z]{2,}\d{3,}(?:-\d+)?/u.exec(moodleCourse.fullname);
     if (codeMatch) {
       candidates.push(codeMatch[0]);
     }
@@ -79,7 +82,7 @@ export class ArchiveEngine {
     this.logger.info(
       {
         candidates: uniqueCandidates,
-        hasEnrolledFilter: !!enrolledCodigos?.length,
+        hasEnrolledFilter: (enrolledCodigos?.length ?? 0) > 0,
       },
       'Extracted candidate codes from moodle course'
     );
@@ -101,22 +104,10 @@ export class ArchiveEngine {
       'Resolved teachers for matching'
     );
 
-    let seasonFilter: { year: number; quad: number } | null = null;
-    if (moodleCourse.startdate) {
-      const date = new Date(moodleCourse.startdate * 1000);
-      if (!Number.isNaN(date.getTime())) {
-        const month = date.getMonth() + 1;
-        const year = date.getFullYear();
-
-        if (month >= 2 && month <= 4) {
-          seasonFilter = { quad: 1, year };
-        } else if (month >= 5 && month <= 8) {
-          seasonFilter = { quad: 2, year };
-        } else if (month >= 9 || month <= 1) {
-          seasonFilter = { quad: 3, year };
-        }
-      }
-    }
+    const seasonFilter =
+      moodleCourse.startdate === undefined
+        ? null
+        : findArchiveQuarter(new Date(moodleCourse.startdate * 1000));
 
     if (seasonFilter) {
       this.logger.info(
@@ -321,8 +312,8 @@ export class ArchiveEngine {
   private static extractKeywords(fullname: string): string[] {
     return fullname
       .toLowerCase()
-      .split(/[\s-]+/)
-      .filter((w) => w.length > 3 && !/\d/.test(w))
+      .split(/[\s-]+/u)
+      .filter((w) => w.length > 3 && !/\d/u.test(w))
       .slice(0, 4);
   }
 
@@ -335,13 +326,13 @@ export class ArchiveEngine {
     ) => Promise<ComponentDocument | null>
   ): Promise<{ component: ComponentDocument; keywordsUsed: string[] } | null> {
     const cleanKeywords = keywords.filter(
-      (w) => w.length > 3 && !/\d/.test(w)
+      (w) => w.length > 3 && !/\d/u.test(w)
     );
     if (cleanKeywords.length === 0) {
       return null;
     }
 
-    for (let count = cleanKeywords.length; count >= 1; count--) {
+    for (let count = cleanKeywords.length; count >= 1; count -= 1) {
       const subset = cleanKeywords.slice(0, count);
       const result = await finder(subset, extraFilter);
       if (result) {
@@ -398,7 +389,7 @@ export class ArchiveEngine {
 
     $('a[href*="user/view.php"]').each((_index, el) => {
       const name = $(el).text().trim();
-      if (name && name.length > 2 && !/^\d+$/.test(name)) {
+      if (name && name.length > 2 && !/^\d+$/u.test(name)) {
         teacherNames.push(name);
       }
     });
@@ -416,7 +407,7 @@ export class ArchiveEngine {
   async extractFiles(viewurl: string, componentId: number) {
     const url = new URL(viewurl);
     const page = await this.moodleConnector.getComponentContentsPage(
-      this.session?.sessionId || '',
+      this.session?.sessionId ?? '',
       url.pathname,
       componentId.toString()
     );
@@ -427,7 +418,7 @@ export class ArchiveEngine {
     $('div.activityname').each((_index, el) => {
       const href = $(el).find('a').attr('href');
       const name = $(el).find('span.instancename').text();
-      if (href && name) {
+      if (href !== undefined && name) {
         potentialLinks.push({ href, name });
       }
     });
@@ -435,33 +426,45 @@ export class ArchiveEngine {
     $('a[href*="/mod/resource/"]').each((_index, el) => {
       const link = $(el).attr('href');
       const name = $(el).text().trim();
-      if (link && name && !potentialLinks.some((p) => p.href === link)) {
+      if (
+        link !== undefined &&
+        name &&
+        !potentialLinks.some((p) => p.href === link)
+      ) {
         potentialLinks.push({ href: link, name });
       }
     });
 
     $('a[href*="/pluginfile.php/"]').each((_index, el) => {
       const link = $(el).attr('href');
-      const name = $(el).text().trim() || $(el).attr('title') || 'documento';
-      if (link?.toLowerCase()?.endsWith('.pdf')) {
-        if (!potentialLinks.some((p) => p.href === link)) {
-          potentialLinks.push({ href: link, name });
-        }
+      const trimmedText = $(el).text().trim();
+      let name = trimmedText;
+      if (name === '') {
+        const titleAttr = $(el).attr('title');
+        name = titleAttr !== undefined && titleAttr !== '' ? titleAttr : 'documento';
+      }
+
+      if (
+        link !== undefined &&
+        link.toLowerCase().endsWith('.pdf') &&
+        !potentialLinks.some((p) => p.href === link)
+      ) {
+        potentialLinks.push({ href: link, name });
       }
     });
 
     const validationPromises = potentialLinks.map(async ({ href, name }) => {
       const { isPdf, finalUrl } = await this.moodleConnector.validatePdfLink(
         href,
-        this.session?.sessionId || '',
-        this.session?.sessKey || ''
+        this.session?.sessionId ?? '',
+        this.session?.sessKey ?? ''
       );
 
       if (!isPdf) {
         return null;
       }
 
-      if (finalUrl) {
+      if (finalUrl !== undefined && finalUrl !== '') {
         return { name, url: finalUrl };
       }
       return null;
@@ -483,7 +486,7 @@ export class ArchiveEngine {
     });
 
     const filename = this.extractFilenameFromUrl(url);
-    const sanitizedFilename = this.sanitizeFilename(filename);
+    const sanitizedFilename = ArchiveEngine.sanitizeFilename(filename);
     const s3Key = `/archives/${componentId}/${sanitizedFilename}`;
 
     await this.s3Connector?.upload(bucket, s3Key, Buffer.from(buffer));
@@ -503,7 +506,7 @@ export class ArchiveEngine {
     const segments = pathname
       .split('/')
       .filter((segment) => segment.length > 0);
-    const lastSegment = segments.at(-1) || 'document.pdf';
+    const lastSegment = segments.at(-1) ?? 'document.pdf';
 
     try {
       return decodeURIComponent(lastSegment);
@@ -512,20 +515,18 @@ export class ArchiveEngine {
     }
   }
 
-  private sanitizeFilename(filename: string): string {
-    const invalidChars = /[<>:"|?*\s]/g;
+  private static sanitizeFilename(filename: string): string {
+    const invalidChars = /[<>:"|?*\s]/u;
 
-    let sanitized = [...filename]
-      .map((char) => {
-        const code = char.codePointAt(0);
-        if (invalidChars.test(char) || (code !== undefined && code <= 31)) {
-          return '_';
-        }
-        return char;
-      })
-      .join('')
-      .replaceAll(/_{2,}/g, '_')
-      .trim();
+    let sanitizedChars = '';
+    for (const char of filename) {
+      const code = char.codePointAt(0);
+      const isInvalid =
+        invalidChars.test(char) || (code !== undefined && code <= 31);
+      sanitizedChars += isInvalid ? '_' : char;
+    }
+
+    let sanitized = sanitizedChars.replaceAll(/_{2,}/gu, '_').trim();
 
     if (!sanitized.toLowerCase().endsWith('.pdf')) {
       sanitized = `${sanitized}.pdf`;

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -1,0 +1,559 @@
+import { load } from 'cheerio';
+import { ofetch } from 'ofetch';
+
+import { MoodleConnector } from '@/connectors/moodle.js';
+import { S3Connector } from '@/connectors/s3-connector.js';
+import { ArchiveParseFailed } from '@/errors/custom-errors.js';
+import { ComponentModel, type ComponentDocument } from '@/models/Component.js';
+import { findTeacher } from '@/models/Teacher.js';
+import { componentArchiveSchema } from '@/schemas/v2/components.js';
+import { logger as baseLogger } from '@/utils/logger.js';
+
+const ACCENT_MAP: Record<string, string> = {
+  a: '[aáàâãAÁÀÂÃ]',
+  e: '[eéêEÉÊ]',
+  i: '[iíIÍ]',
+  o: '[oóôõOÓÔÕ]',
+  u: '[uúüUÚÜ]',
+  c: '[cçCÇ]',
+};
+
+function buildAccentInsensitiveRegex(word: string): string {
+  let pattern = '';
+  for (const char of word.toLowerCase()) {
+    pattern += ACCENT_MAP[char] ?? char;
+  }
+  return pattern;
+}
+
+export type MoodleSession = {
+  sessionId: string;
+  sessKey: string;
+};
+
+export type MoodleCourse = {
+  viewurl: string;
+  fullname: string;
+  shortname?: string;
+  idnumber?: string;
+  id: number;
+  startdate?: number;
+};
+
+function deriveSeason(
+  startdate: number
+): { year: number; quad: number } | null {
+  const date = new Date(startdate * 1000);
+  if (isNaN(date.getTime())) return null;
+
+  const month = date.getMonth() + 1;
+  const year = date.getFullYear();
+
+  let quad: number;
+  if (month >= 2 && month <= 4) quad = 1;
+  else if (month >= 5 && month <= 8) quad = 2;
+  else if (month >= 9 || month <= 1) quad = 3;
+  else return null;
+
+  return { year, quad };
+}
+
+function extractKeywords(fullname: string): string[] {
+  return fullname
+    .toLowerCase()
+    .split(/[\s-]+/)
+    .filter((w) => w.length > 3 && !/\d/.test(w))
+    .slice(0, 4);
+}
+
+async function relaxedKeywordSearch(
+  keywords: string[],
+  extraFilter: Record<string, unknown>,
+  finder: (
+    subset: string[],
+    filter: Record<string, unknown>
+  ) => Promise<ComponentDocument | null>
+): Promise<{ component: ComponentDocument; keywordsUsed: string[] } | null> {
+  const cleanKeywords = keywords.filter((w) => w.length > 3 && !/\d/.test(w));
+  if (cleanKeywords.length === 0) return null;
+
+  for (let count = cleanKeywords.length; count >= 1; count--) {
+    const subset = cleanKeywords.slice(0, count);
+    const result = await finder(subset, extraFilter);
+    if (result) {
+      return { component: result, keywordsUsed: subset };
+    }
+  }
+
+  return null;
+}
+
+export class ArchiveEngine {
+  private readonly logger;
+  private readonly moodleConnector;
+  private readonly session?: MoodleSession;
+  private readonly s3Connector?: S3Connector;
+
+  constructor({
+    globalTraceId,
+    session,
+    s3Connector,
+  }: {
+    globalTraceId?: string;
+    session?: MoodleSession;
+    s3Connector?: S3Connector;
+  } = {}) {
+    this.logger = baseLogger.child({ globalTraceId });
+    this.moodleConnector = new MoodleConnector(globalTraceId);
+    this.session = session;
+    this.s3Connector = s3Connector;
+  }
+
+  async findComponentByMoodleCourse(
+    moodleCourse: MoodleCourse,
+    teacherNames?: string[],
+    enrolledCodigos?: string[]
+  ): Promise<ComponentDocument | null> {
+    this.logger.info(
+      { courseId: moodleCourse.id, courseName: moodleCourse.fullname },
+      'Matching moodle course to internal component'
+    );
+
+    const candidates: string[] = [];
+
+    if (moodleCourse.idnumber) {
+      candidates.push(moodleCourse.idnumber);
+    }
+
+    if (moodleCourse.shortname) {
+      const codeMatch = moodleCourse.shortname.match(
+        /[A-Z]{2,}\d{3,}(?:-\d+)?/
+      );
+      if (codeMatch) {
+        candidates.push(codeMatch[0]);
+      }
+    }
+
+    const codeMatch = moodleCourse.fullname.match(/[A-Z]{2,}\d{3,}(?:-\d+)?/);
+    if (codeMatch) {
+      candidates.push(codeMatch[0]);
+    }
+
+    const uniqueCandidates = [...new Set(candidates)];
+    this.logger.info(
+      {
+        candidates: uniqueCandidates,
+        hasEnrolledFilter: !!enrolledCodigos?.length,
+      },
+      'Extracted candidate codes from moodle course'
+    );
+
+    const teacherIds: string[] = [];
+    if (teacherNames && teacherNames.length > 0) {
+      for (const teacherName of teacherNames) {
+        const teacherId = await findTeacher(teacherName);
+        if (teacherId) {
+          teacherIds.push(teacherId.toString());
+        }
+      }
+    }
+
+    const uniqueTeacherIds = [...new Set(teacherIds)];
+
+    this.logger.info(
+      { teacherIds: uniqueTeacherIds, count: uniqueTeacherIds.length },
+      'Resolved teachers for matching'
+    );
+
+    const seasonFilter = moodleCourse.startdate
+      ? deriveSeason(moodleCourse.startdate)
+      : null;
+
+    if (seasonFilter) {
+      this.logger.info(
+        { derivedSeason: `${seasonFilter.year}:${seasonFilter.quad}` },
+        'Derived season from moodle course startdate'
+      );
+    }
+
+    const sortDesc = { year: -1 as const, quad: -1 as const };
+
+    const tryStrategies = async (
+      extraFilter: Record<string, unknown> = {}
+    ): Promise<ComponentDocument | null> => {
+      const findByKeywords = async (
+        keywords: string[],
+        extraFilterInner: Record<string, unknown> = {}
+      ): Promise<ComponentDocument | null> => {
+        if (keywords.length === 0) return null;
+
+        const regexConditions = keywords.map((w) => ({
+          disciplina: { $regex: buildAccentInsensitiveRegex(w) },
+        }));
+
+        return await ComponentModel.findOne({
+          $and: regexConditions,
+          ...extraFilterInner,
+        }).sort(sortDesc);
+      };
+
+      const enrolledCodigosFilter =
+        enrolledCodigos && enrolledCodigos.length > 0
+          ? { codigo: { $in: enrolledCodigos } }
+          : {};
+
+      const isCodeAllowed =
+        enrolledCodigos && enrolledCodigos.length > 0
+          ? (code: string) => enrolledCodigos.includes(code)
+          : () => true;
+
+      // Strategy 1: candidate code + teacher
+      if (uniqueCandidates.length > 0) {
+        const teacherFilter =
+          uniqueTeacherIds.length > 0
+            ? {
+                $or: [
+                  { teoria: { $in: uniqueTeacherIds } },
+                  { pratica: { $in: uniqueTeacherIds } },
+                ],
+              }
+            : {};
+
+        for (const candidateCode of uniqueCandidates) {
+          if (!isCodeAllowed(candidateCode)) {
+            this.logger.info(
+              { candidateCode },
+              'Skipping candidate code not in enrollments'
+            );
+            continue;
+          }
+
+          const result = await ComponentModel.findOne({
+            codigo: candidateCode,
+            ...teacherFilter,
+            ...extraFilter,
+          }).sort(sortDesc);
+
+          if (result) {
+            this.logger.info(
+              {
+                candidateCode,
+                componentDbId: result._id,
+                componentName: result.disciplina,
+                season: `${result.year}:${result.quad}`,
+              },
+              'Matched component by candidate code'
+            );
+            return result;
+          }
+        }
+
+        // Strategy 2: candidate code only
+        if (uniqueTeacherIds.length > 0) {
+          for (const candidateCode of uniqueCandidates) {
+            if (!isCodeAllowed(candidateCode)) {
+              continue;
+            }
+            const result = await ComponentModel.findOne({
+              codigo: candidateCode,
+              ...extraFilter,
+            }).sort(sortDesc);
+
+            if (result) {
+              this.logger.info(
+                {
+                  candidateCode,
+                  componentDbId: result._id,
+                  componentName: result.disciplina,
+                  season: `${result.year}:${result.quad}`,
+                },
+                'Matched component by candidate code (no teacher)'
+              );
+              return result;
+            }
+          }
+        }
+      }
+
+      // Strategy 3: disciplina keyword + teacher
+      if (uniqueTeacherIds.length > 0) {
+        const keywords = extractKeywords(moodleCourse.fullname);
+        this.logger.info(
+          { keywords },
+          'No candidate match, trying disciplina keywords'
+        );
+
+        const match = await relaxedKeywordSearch(
+          keywords,
+          {
+            $or: [
+              { teoria: { $in: uniqueTeacherIds } },
+              { pratica: { $in: uniqueTeacherIds } },
+            ],
+            ...extraFilter,
+            ...enrolledCodigosFilter,
+          },
+          findByKeywords
+        );
+
+        if (match) {
+          this.logger.info(
+            {
+              keywords: match.keywordsUsed,
+              componentDbId: match.component._id,
+              componentName: match.component.disciplina,
+              season: `${match.component.year}:${match.component.quad}`,
+            },
+            'Matched component by disciplina keywords'
+          );
+          return match.component;
+        }
+      }
+
+      // Strategy 4: disciplina keyword only
+      {
+        const keywords = extractKeywords(moodleCourse.fullname);
+
+        const match = await relaxedKeywordSearch(
+          keywords,
+          { ...extraFilter, ...enrolledCodigosFilter },
+          findByKeywords
+        );
+
+        if (match) {
+          this.logger.info(
+            {
+              keywords: match.keywordsUsed,
+              componentDbId: match.component._id,
+              componentName: match.component.disciplina,
+              season: `${match.component.year}:${match.component.quad}`,
+            },
+            'Matched component by disciplina keywords (no teacher)'
+          );
+          return match.component;
+        }
+      }
+
+      return null;
+    };
+
+    let matchedComponent: ComponentDocument | null = null;
+
+    // Try with season filter first
+    const seasonExtra = seasonFilter
+      ? { year: seasonFilter.year, quad: seasonFilter.quad }
+      : {};
+
+    matchedComponent = await tryStrategies(seasonExtra);
+
+    // Fall back to tenant-free if no match
+    if (!matchedComponent) {
+      this.logger.info(
+        'No match with season filter, falling back to tenant-free'
+      );
+      matchedComponent = await tryStrategies();
+    }
+
+    if (matchedComponent) {
+      await ComponentModel.findByIdAndUpdate(matchedComponent._id, {
+        $set: { moodleCourseId: moodleCourse.id },
+      });
+
+      this.logger.info(
+        {
+          componentDbId: matchedComponent._id,
+          moodleCourseId: moodleCourse.id,
+          componentName: matchedComponent.disciplina,
+        },
+        'Updated component with moodleCourseId'
+      );
+
+      return matchedComponent;
+    }
+
+    this.logger.warn(
+      { moodleCourseId: moodleCourse.id, courseName: moodleCourse.fullname },
+      'No matching component found'
+    );
+    return null;
+  }
+
+  async fetchAndValidateCourses(session: MoodleSession) {
+    const [moodleCourses] = await this.moodleConnector.getComponents(
+      session.sessionId,
+      session.sessKey
+    );
+    const parsed = componentArchiveSchema.safeParse(
+      moodleCourses?.data?.courses
+    );
+
+    if (!parsed.success) {
+      this.logger.warn(
+        { error: parsed.error.message },
+        'Failed to parse component archives'
+      );
+      throw new ArchiveParseFailed(parsed.error.message);
+    }
+
+    return parsed.data!;
+  }
+
+  async extractTeacherNames(courseId: number) {
+    if (!this.session) {
+      this.logger.warn('No session available for teacher extraction');
+      return [];
+    }
+
+    const html = await this.moodleConnector.getUsersByCoursePage(
+      this.session.sessionId,
+      courseId
+    );
+
+    const $ = load(html);
+    const teacherNames: string[] = [];
+
+    $('a[href*="user/view.php"]').each((_index, el) => {
+      const name = $(el).text().trim();
+      if (name && name.length > 2 && !/^\d+$/.test(name)) {
+        teacherNames.push(name);
+      }
+    });
+
+    const uniqueNames = [...new Set(teacherNames)];
+
+    this.logger.info(
+      { teacherNames: uniqueNames, courseId, count: uniqueNames.length },
+      'Found teachers via user/index.php'
+    );
+
+    return uniqueNames;
+  }
+
+  async extractFiles(viewurl: string, componentId: number) {
+    const url = new URL(viewurl);
+    const page = await this.moodleConnector.getComponentContentsPage(
+      this.session?.sessionId || '',
+      url.pathname,
+      componentId.toString()
+    );
+
+    const $ = load(page);
+    const potentialLinks: { href: string; name: string }[] = [];
+
+    $('div.activityname').each((_index, el) => {
+      const href = $(el).find('a').attr('href');
+      const name = $(el).find('span.instancename').text();
+      if (href && name) {
+        potentialLinks.push({ href, name });
+      }
+    });
+
+    $('a[href*="/mod/resource/"]').each((_index, el) => {
+      const link = $(el).attr('href');
+      const name = $(el).text().trim();
+      if (link && name && !potentialLinks.some((p) => p.href === link)) {
+        potentialLinks.push({ href: link, name });
+      }
+    });
+
+    $('a[href*="/pluginfile.php/"]').each((_index, el) => {
+      const link = $(el).attr('href');
+      const name = $(el).text().trim() || $(el).attr('title') || 'documento';
+      if (link?.toLowerCase()?.endsWith('.pdf')) {
+        if (!potentialLinks.some((p) => p.href === link)) {
+          potentialLinks.push({ href: link, name });
+        }
+      }
+    });
+
+    const validationPromises = potentialLinks.map(async ({ href, name }) => {
+      const { isPdf, finalUrl } = await this.moodleConnector.validatePdfLink(
+        href,
+        this.session?.sessionId || '',
+        this.session?.sessKey || ''
+      );
+
+      if (!isPdf) {
+        return null;
+      }
+
+      if (finalUrl) {
+        return { url: finalUrl, name };
+      }
+      return null;
+    });
+
+    const validatedLinks = await Promise.all(validationPromises);
+    return validatedLinks.filter((link) => link !== null);
+  }
+
+  async downloadAndUpload(rawUrl: string, componentId: string, bucket: string) {
+    const url = new URL(rawUrl);
+    const headers: Record<string, string> = {};
+    if (this.session) {
+      headers.Cookie = `MoodleSession=${this.session.sessionId}`;
+    }
+    const buffer = await ofetch(url.href, {
+      responseType: 'arrayBuffer',
+      headers,
+    });
+
+    const filename = this.extractFilenameFromUrl(url);
+    const sanitizedFilename = this.sanitizeFilename(filename);
+    const s3Key = `/archives/${componentId}/${sanitizedFilename}`;
+
+    await this.s3Connector?.upload(bucket, s3Key, Buffer.from(buffer));
+
+    return {
+      s3Key,
+      pdfName: sanitizedFilename,
+    };
+  }
+
+  private extractFilenameFromUrl(url: URL): string {
+    const pathname = url.pathname;
+    this.logger.info(
+      { url: url.href, pathname },
+      'Extracting filename from URL'
+    );
+    const segments = pathname
+      .split('/')
+      .filter((segment) => segment.length > 0);
+    const lastSegment = segments[segments.length - 1] || 'document.pdf';
+
+    try {
+      return decodeURIComponent(lastSegment);
+    } catch {
+      return lastSegment;
+    }
+  }
+
+  private sanitizeFilename(filename: string): string {
+    const invalidChars = /[<>:"|?*\s]/g;
+
+    let sanitized = filename
+      .split('')
+      .map((char) => {
+        const code = char.charCodeAt(0);
+        if (invalidChars.test(char) || (code >= 0 && code <= 31)) {
+          return '_';
+        }
+        return char;
+      })
+      .join('')
+      .replace(/_{2,}/g, '_')
+      .trim();
+
+    if (!sanitized.toLowerCase().endsWith('.pdf')) {
+      sanitized = `${sanitized}.pdf`;
+    }
+
+    if (sanitized.length > 255) {
+      const ext = '.pdf';
+      const nameWithoutExt = sanitized.slice(0, 255 - ext.length);
+      sanitized = `${nameWithoutExt}${ext}`;
+    }
+
+    return sanitized || 'document.pdf';
+  }
+}

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -2,7 +2,7 @@ import { load } from 'cheerio';
 import { ofetch } from 'ofetch';
 
 import { MoodleConnector } from '@/connectors/moodle.js';
-import { S3Connector } from '@/connectors/s3-connector.js';
+import type { S3Connector } from '@/connectors/s3-connector.js';
 import { ArchiveParseFailed } from '@/errors/custom-errors.js';
 import type { ComponentDocument } from '@/models/Component.js';
 import { findTeacher } from '@/models/Teacher.js';
@@ -24,24 +24,6 @@ export type MoodleCourse = {
   startdate?: number;
 };
 
-function deriveSeason(
-  startdate: number
-): { year: number; quad: number } | null {
-  const date = new Date(startdate * 1000);
-  if (isNaN(date.getTime())) return null;
-
-  const month = date.getMonth() + 1;
-  const year = date.getFullYear();
-
-  let quad: number;
-  if (month >= 2 && month <= 4) quad = 1;
-  else if (month >= 5 && month <= 8) quad = 2;
-  else if (month >= 9 || month <= 1) quad = 3;
-  else return null;
-
-  return { year, quad };
-}
-
 function extractKeywords(fullname: string): string[] {
   return fullname
     .toLowerCase()
@@ -59,7 +41,9 @@ async function relaxedKeywordSearch(
   ) => Promise<ComponentDocument | null>
 ): Promise<{ component: ComponentDocument; keywordsUsed: string[] } | null> {
   const cleanKeywords = keywords.filter((w) => w.length > 3 && !/\d/.test(w));
-  if (cleanKeywords.length === 0) return null;
+  if (cleanKeywords.length === 0) {
+    return null;
+  }
 
   for (let count = cleanKeywords.length; count >= 1; count--) {
     const subset = cleanKeywords.slice(0, count);
@@ -99,7 +83,7 @@ export class ArchiveEngine {
     moodleCourse: MoodleCourse,
     teacherNames?: string[],
     enrolledCodigos?: string[]
-  ): Promise<ComponentDocument | null> {
+  ) {
     this.logger.info(
       { courseId: moodleCourse.id, courseName: moodleCourse.fullname },
       'Matching moodle course to internal component'
@@ -107,20 +91,18 @@ export class ArchiveEngine {
 
     const candidates: string[] = [];
 
-    if (moodleCourse.idnumber) {
+    if (moodleCourse.idnumber != null) {
       candidates.push(moodleCourse.idnumber);
     }
 
-    if (moodleCourse.shortname) {
-      const codeMatch = moodleCourse.shortname.match(
-        /[A-Z]{2,}\d{3,}(?:-\d+)?/
-      );
+    if (moodleCourse.shortname != null) {
+      const codeMatch = /[A-Z]{2,}\d{3,}(?:-\d+)?/.exec(moodleCourse.shortname);
       if (codeMatch) {
         candidates.push(codeMatch[0]);
       }
     }
 
-    const codeMatch = moodleCourse.fullname.match(/[A-Z]{2,}\d{3,}(?:-\d+)?/);
+    const codeMatch = /[A-Z]{2,}\d{3,}(?:-\d+)?/.exec(moodleCourse.fullname);
     if (codeMatch) {
       candidates.push(codeMatch[0]);
     }
@@ -147,13 +129,26 @@ export class ArchiveEngine {
     const uniqueTeacherIds = [...new Set(teacherIds)];
 
     this.logger.info(
-      { teacherIds: uniqueTeacherIds, count: uniqueTeacherIds.length },
+      { count: uniqueTeacherIds.length, teacherIds: uniqueTeacherIds },
       'Resolved teachers for matching'
     );
 
-    const seasonFilter = moodleCourse.startdate
-      ? deriveSeason(moodleCourse.startdate)
-      : null;
+    let seasonFilter: { year: number; quad: number } | null = null;
+    if (moodleCourse.startdate) {
+      const date = new Date(moodleCourse.startdate * 1000);
+      if (!Number.isNaN(date.getTime())) {
+        const month = date.getMonth() + 1;
+        const year = date.getFullYear();
+
+        if (month >= 2 && month <= 4) {
+          seasonFilter = { quad: 1, year };
+        } else if (month >= 5 && month <= 8) {
+          seasonFilter = { quad: 2, year };
+        } else if (month >= 9 || month <= 1) {
+          seasonFilter = { quad: 3, year };
+        }
+      }
+    }
 
     if (seasonFilter) {
       this.logger.info(
@@ -165,11 +160,11 @@ export class ArchiveEngine {
     const tryStrategies = async (
       extraFilter: Record<string, unknown> = {}
     ): Promise<ComponentDocument | null> => {
-      const findByKeywords = (
+      const findByKeywords = async (
         keywords: string[],
         extraFilterInner: Record<string, unknown> = {}
       ): Promise<ComponentDocument | null> =>
-        this.componentsRepository.findByDisciplinaKeywords(
+        await this.componentsRepository.findByDisciplinaKeywords(
           keywords,
           extraFilterInner
         );
@@ -275,9 +270,9 @@ export class ArchiveEngine {
         if (match) {
           this.logger.info(
             {
-              keywords: match.keywordsUsed,
               componentDbId: match.component._id,
               componentName: match.component.disciplina,
+              keywords: match.keywordsUsed,
               season: `${match.component.year}:${match.component.quad}`,
             },
             'Matched component by disciplina keywords'
@@ -299,9 +294,9 @@ export class ArchiveEngine {
         if (match) {
           this.logger.info(
             {
-              keywords: match.keywordsUsed,
               componentDbId: match.component._id,
               componentName: match.component.disciplina,
+              keywords: match.keywordsUsed,
               season: `${match.component.year}:${match.component.quad}`,
             },
             'Matched component by disciplina keywords (no teacher)'
@@ -317,7 +312,7 @@ export class ArchiveEngine {
 
     // Try with season filter first
     const seasonExtra = seasonFilter
-      ? { year: seasonFilter.year, quad: seasonFilter.quad }
+      ? { quad: seasonFilter.quad, year: seasonFilter.year }
       : {};
 
     matchedComponent = await tryStrategies(seasonExtra);
@@ -339,8 +334,8 @@ export class ArchiveEngine {
       this.logger.info(
         {
           componentDbId: matchedComponent._id,
-          moodleCourseId: moodleCourse.id,
           componentName: matchedComponent.disciplina,
+          moodleCourseId: moodleCourse.id,
         },
         'Updated component with moodleCourseId'
       );
@@ -349,7 +344,7 @@ export class ArchiveEngine {
     }
 
     this.logger.warn(
-      { moodleCourseId: moodleCourse.id, courseName: moodleCourse.fullname },
+      { courseName: moodleCourse.fullname, moodleCourseId: moodleCourse.id },
       'No matching component found'
     );
     return null;
@@ -382,7 +377,7 @@ export class ArchiveEngine {
       throw new ArchiveParseFailed(parsed.error.message);
     }
 
-    return parsed.data!;
+    return parsed.data;
   }
 
   async extractTeacherNames(courseId: number) {
@@ -409,7 +404,7 @@ export class ArchiveEngine {
     const uniqueNames = [...new Set(teacherNames)];
 
     this.logger.info(
-      { teacherNames: uniqueNames, courseId, count: uniqueNames.length },
+      { count: uniqueNames.length, courseId, teacherNames: uniqueNames },
       'Found teachers via user/index.php'
     );
 
@@ -425,7 +420,7 @@ export class ArchiveEngine {
     );
 
     const $ = load(page);
-    const potentialLinks: { href: string; name: string }[] = [];
+    const potentialLinks: Array<{ href: string; name: string }> = [];
 
     $('div.activityname').each((_index, el) => {
       const href = $(el).find('a').attr('href');
@@ -465,7 +460,7 @@ export class ArchiveEngine {
       }
 
       if (finalUrl) {
-        return { url: finalUrl, name };
+        return { name, url: finalUrl };
       }
       return null;
     });
@@ -481,8 +476,8 @@ export class ArchiveEngine {
       headers.Cookie = `MoodleSession=${this.session.sessionId}`;
     }
     const buffer = await ofetch(url.href, {
-      responseType: 'arrayBuffer',
       headers,
+      responseType: 'arrayBuffer',
     });
 
     const filename = this.extractFilenameFromUrl(url);
@@ -492,21 +487,21 @@ export class ArchiveEngine {
     await this.s3Connector?.upload(bucket, s3Key, Buffer.from(buffer));
 
     return {
-      s3Key,
       pdfName: sanitizedFilename,
+      s3Key,
     };
   }
 
   private extractFilenameFromUrl(url: URL): string {
-    const pathname = url.pathname;
+    const { pathname } = url;
     this.logger.info(
-      { url: url.href, pathname },
+      { pathname, url: url.href },
       'Extracting filename from URL'
     );
     const segments = pathname
       .split('/')
       .filter((segment) => segment.length > 0);
-    const lastSegment = segments[segments.length - 1] || 'document.pdf';
+    const lastSegment = segments.at(-1) || 'document.pdf';
 
     try {
       return decodeURIComponent(lastSegment);
@@ -518,17 +513,16 @@ export class ArchiveEngine {
   private sanitizeFilename(filename: string): string {
     const invalidChars = /[<>:"|?*\s]/g;
 
-    let sanitized = filename
-      .split('')
+    let sanitized = [...filename]
       .map((char) => {
-        const code = char.charCodeAt(0);
-        if (invalidChars.test(char) || (code >= 0 && code <= 31)) {
+        const code = char.codePointAt(0);
+        if (invalidChars.test(char) || (code !== undefined && code <= 31)) {
           return '_';
         }
         return char;
       })
       .join('')
-      .replace(/_{2,}/g, '_')
+      .replaceAll(/_{2,}/g, '_')
       .trim();
 
     if (!sanitized.toLowerCase().endsWith('.pdf')) {

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -4,27 +4,11 @@ import { ofetch } from 'ofetch';
 import { MoodleConnector } from '@/connectors/moodle.js';
 import { S3Connector } from '@/connectors/s3-connector.js';
 import { ArchiveParseFailed } from '@/errors/custom-errors.js';
-import { ComponentModel, type ComponentDocument } from '@/models/Component.js';
+import type { ComponentDocument } from '@/models/Component.js';
 import { findTeacher } from '@/models/Teacher.js';
+import { ComponentsRepository } from '@/repositories/components-repository.js';
 import { componentArchiveSchema } from '@/schemas/v2/components.js';
 import { logger as baseLogger } from '@/utils/logger.js';
-
-const ACCENT_MAP: Record<string, string> = {
-  a: '[aáàâãAÁÀÂÃ]',
-  e: '[eéêEÉÊ]',
-  i: '[iíIÍ]',
-  o: '[oóôõOÓÔÕ]',
-  u: '[uúüUÚÜ]',
-  c: '[cçCÇ]',
-};
-
-function buildAccentInsensitiveRegex(word: string): string {
-  let pattern = '';
-  for (const char of word.toLowerCase()) {
-    pattern += ACCENT_MAP[char] ?? char;
-  }
-  return pattern;
-}
 
 export type MoodleSession = {
   sessionId: string;
@@ -91,6 +75,7 @@ async function relaxedKeywordSearch(
 export class ArchiveEngine {
   private readonly logger;
   private readonly moodleConnector;
+  private readonly componentsRepository: ComponentsRepository;
   private readonly session?: MoodleSession;
   private readonly s3Connector?: S3Connector;
 
@@ -105,6 +90,7 @@ export class ArchiveEngine {
   } = {}) {
     this.logger = baseLogger.child({ globalTraceId });
     this.moodleConnector = new MoodleConnector({ globalTraceId });
+    this.componentsRepository = new ComponentsRepository({ globalTraceId });
     this.session = session;
     this.s3Connector = s3Connector;
   }
@@ -176,26 +162,17 @@ export class ArchiveEngine {
       );
     }
 
-    const sortDesc = { year: -1 as const, quad: -1 as const };
-
     const tryStrategies = async (
       extraFilter: Record<string, unknown> = {}
     ): Promise<ComponentDocument | null> => {
-      const findByKeywords = async (
+      const findByKeywords = (
         keywords: string[],
         extraFilterInner: Record<string, unknown> = {}
-      ): Promise<ComponentDocument | null> => {
-        if (keywords.length === 0) return null;
-
-        const regexConditions = keywords.map((w) => ({
-          disciplina: { $regex: buildAccentInsensitiveRegex(w) },
-        }));
-
-        return await ComponentModel.findOne({
-          $and: regexConditions,
-          ...extraFilterInner,
-        }).sort(sortDesc);
-      };
+      ): Promise<ComponentDocument | null> =>
+        this.componentsRepository.findByDisciplinaKeywords(
+          keywords,
+          extraFilterInner
+        );
 
       const enrolledCodigosFilter =
         enrolledCodigos && enrolledCodigos.length > 0
@@ -228,11 +205,10 @@ export class ArchiveEngine {
             continue;
           }
 
-          const result = await ComponentModel.findOne({
-            codigo: candidateCode,
-            ...teacherFilter,
-            ...extraFilter,
-          }).sort(sortDesc);
+          const result = await this.componentsRepository.findByCodigo(
+            candidateCode,
+            { ...teacherFilter, ...extraFilter }
+          );
 
           if (result) {
             this.logger.info(
@@ -254,10 +230,10 @@ export class ArchiveEngine {
             if (!isCodeAllowed(candidateCode)) {
               continue;
             }
-            const result = await ComponentModel.findOne({
-              codigo: candidateCode,
-              ...extraFilter,
-            }).sort(sortDesc);
+            const result = await this.componentsRepository.findByCodigo(
+              candidateCode,
+              extraFilter
+            );
 
             if (result) {
               this.logger.info(
@@ -355,9 +331,10 @@ export class ArchiveEngine {
     }
 
     if (matchedComponent) {
-      await ComponentModel.findByIdAndUpdate(matchedComponent._id, {
-        $set: { moodleCourseId: moodleCourse.id },
-      });
+      await this.componentsRepository.setMoodleCourseId(
+        matchedComponent._id,
+        moodleCourse.id
+      );
 
       this.logger.info(
         {

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -24,38 +24,6 @@ export type MoodleCourse = {
   startdate?: number;
 };
 
-function extractKeywords(fullname: string): string[] {
-  return fullname
-    .toLowerCase()
-    .split(/[\s-]+/)
-    .filter((w) => w.length > 3 && !/\d/.test(w))
-    .slice(0, 4);
-}
-
-async function relaxedKeywordSearch(
-  keywords: string[],
-  extraFilter: Record<string, unknown>,
-  finder: (
-    subset: string[],
-    filter: Record<string, unknown>
-  ) => Promise<ComponentDocument | null>
-): Promise<{ component: ComponentDocument; keywordsUsed: string[] } | null> {
-  const cleanKeywords = keywords.filter((w) => w.length > 3 && !/\d/.test(w));
-  if (cleanKeywords.length === 0) {
-    return null;
-  }
-
-  for (let count = cleanKeywords.length; count >= 1; count--) {
-    const subset = cleanKeywords.slice(0, count);
-    const result = await finder(subset, extraFilter);
-    if (result) {
-      return { component: result, keywordsUsed: subset };
-    }
-  }
-
-  return null;
-}
-
 export class ArchiveEngine {
   private readonly logger;
   private readonly moodleConnector;
@@ -248,13 +216,13 @@ export class ArchiveEngine {
 
       // Strategy 3: disciplina keyword + teacher
       if (uniqueTeacherIds.length > 0) {
-        const keywords = extractKeywords(moodleCourse.fullname);
+        const keywords = ArchiveEngine.extractKeywords(moodleCourse.fullname);
         this.logger.info(
           { keywords },
           'No candidate match, trying disciplina keywords'
         );
 
-        const match = await relaxedKeywordSearch(
+        const match = await ArchiveEngine.relaxedKeywordSearch(
           keywords,
           {
             $or: [
@@ -283,9 +251,9 @@ export class ArchiveEngine {
 
       // Strategy 4: disciplina keyword only
       {
-        const keywords = extractKeywords(moodleCourse.fullname);
+        const keywords = ArchiveEngine.extractKeywords(moodleCourse.fullname);
 
-        const match = await relaxedKeywordSearch(
+        const match = await ArchiveEngine.relaxedKeywordSearch(
           keywords,
           { ...extraFilter, ...enrolledCodigosFilter },
           findByKeywords
@@ -347,6 +315,40 @@ export class ArchiveEngine {
       { courseName: moodleCourse.fullname, moodleCourseId: moodleCourse.id },
       'No matching component found'
     );
+    return null;
+  }
+
+  private static extractKeywords(fullname: string): string[] {
+    return fullname
+      .toLowerCase()
+      .split(/[\s-]+/)
+      .filter((w) => w.length > 3 && !/\d/.test(w))
+      .slice(0, 4);
+  }
+
+  private static async relaxedKeywordSearch(
+    keywords: string[],
+    extraFilter: Record<string, unknown>,
+    finder: (
+      subset: string[],
+      filter: Record<string, unknown>
+    ) => Promise<ComponentDocument | null>
+  ): Promise<{ component: ComponentDocument; keywordsUsed: string[] } | null> {
+    const cleanKeywords = keywords.filter(
+      (w) => w.length > 3 && !/\d/.test(w)
+    );
+    if (cleanKeywords.length === 0) {
+      return null;
+    }
+
+    for (let count = cleanKeywords.length; count >= 1; count--) {
+      const subset = cleanKeywords.slice(0, count);
+      const result = await finder(subset, extraFilter);
+      if (result) {
+        return { component: result, keywordsUsed: subset };
+      }
+    }
+
     return null;
   }
 

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -116,157 +116,6 @@ export class ArchiveEngine {
       );
     }
 
-    const tryStrategies = async (
-      extraFilter: Record<string, unknown> = {}
-    ): Promise<ComponentDocument | null> => {
-      const findByKeywords = async (
-        keywords: string[],
-        extraFilterInner: Record<string, unknown> = {}
-      ): Promise<ComponentDocument | null> =>
-        await this.componentsRepository.findByDisciplinaKeywords(
-          keywords,
-          extraFilterInner
-        );
-
-      const enrolledCodigosFilter =
-        enrolledCodigos && enrolledCodigos.length > 0
-          ? { codigo: { $in: enrolledCodigos } }
-          : {};
-
-      const isCodeAllowed =
-        enrolledCodigos && enrolledCodigos.length > 0
-          ? (code: string) => enrolledCodigos.includes(code)
-          : () => true;
-
-      // Strategy 1: candidate code + teacher
-      if (uniqueCandidates.length > 0) {
-        const teacherFilter =
-          uniqueTeacherIds.length > 0
-            ? {
-                $or: [
-                  { teoria: { $in: uniqueTeacherIds } },
-                  { pratica: { $in: uniqueTeacherIds } },
-                ],
-              }
-            : {};
-
-        for (const candidateCode of uniqueCandidates) {
-          if (!isCodeAllowed(candidateCode)) {
-            this.logger.info(
-              { candidateCode },
-              'Skipping candidate code not in enrollments'
-            );
-            continue;
-          }
-
-          const result = await this.componentsRepository.findByCodigo(
-            candidateCode,
-            { ...teacherFilter, ...extraFilter }
-          );
-
-          if (result) {
-            this.logger.info(
-              {
-                candidateCode,
-                componentDbId: result._id,
-                componentName: result.disciplina,
-                season: `${result.year}:${result.quad}`,
-              },
-              'Matched component by candidate code'
-            );
-            return result;
-          }
-        }
-
-        // Strategy 2: candidate code only
-        if (uniqueTeacherIds.length > 0) {
-          for (const candidateCode of uniqueCandidates) {
-            if (!isCodeAllowed(candidateCode)) {
-              continue;
-            }
-            const result = await this.componentsRepository.findByCodigo(
-              candidateCode,
-              extraFilter
-            );
-
-            if (result) {
-              this.logger.info(
-                {
-                  candidateCode,
-                  componentDbId: result._id,
-                  componentName: result.disciplina,
-                  season: `${result.year}:${result.quad}`,
-                },
-                'Matched component by candidate code (no teacher)'
-              );
-              return result;
-            }
-          }
-        }
-      }
-
-      // Strategy 3: disciplina keyword + teacher
-      if (uniqueTeacherIds.length > 0) {
-        const keywords = ArchiveEngine.extractKeywords(moodleCourse.fullname);
-        this.logger.info(
-          { keywords },
-          'No candidate match, trying disciplina keywords'
-        );
-
-        const match = await ArchiveEngine.relaxedKeywordSearch(
-          keywords,
-          {
-            $or: [
-              { teoria: { $in: uniqueTeacherIds } },
-              { pratica: { $in: uniqueTeacherIds } },
-            ],
-            ...extraFilter,
-            ...enrolledCodigosFilter,
-          },
-          findByKeywords
-        );
-
-        if (match) {
-          this.logger.info(
-            {
-              componentDbId: match.component._id,
-              componentName: match.component.disciplina,
-              keywords: match.keywordsUsed,
-              season: `${match.component.year}:${match.component.quad}`,
-            },
-            'Matched component by disciplina keywords'
-          );
-          return match.component;
-        }
-      }
-
-      // Strategy 4: disciplina keyword only
-      {
-        const keywords = ArchiveEngine.extractKeywords(moodleCourse.fullname);
-
-        const match = await ArchiveEngine.relaxedKeywordSearch(
-          keywords,
-          { ...extraFilter, ...enrolledCodigosFilter },
-          findByKeywords
-        );
-
-        if (match) {
-          this.logger.info(
-            {
-              componentDbId: match.component._id,
-              componentName: match.component.disciplina,
-              keywords: match.keywordsUsed,
-              season: `${match.component.year}:${match.component.quad}`,
-            },
-            'Matched component by disciplina keywords (no teacher)'
-          );
-          return match.component;
-        }
-      }
-
-      return null;
-    };
-
     let matchedComponent: ComponentDocument | null = null;
 
     // Try with season filter first
@@ -274,14 +123,25 @@ export class ArchiveEngine {
       ? { quad: seasonFilter.quad, year: seasonFilter.year }
       : {};
 
-    matchedComponent = await tryStrategies(seasonExtra);
+    matchedComponent = await this.matchComponentStrategies(
+      moodleCourse,
+      uniqueCandidates,
+      uniqueTeacherIds,
+      enrolledCodigos,
+      seasonExtra
+    );
 
     // Fall back to tenant-free if no match
     if (!matchedComponent) {
       this.logger.info(
         'No match with season filter, falling back to tenant-free'
       );
-      matchedComponent = await tryStrategies();
+      matchedComponent = await this.matchComponentStrategies(
+        moodleCourse,
+        uniqueCandidates,
+        uniqueTeacherIds,
+        enrolledCodigos
+      );
     }
 
     if (matchedComponent) {
@@ -306,6 +166,161 @@ export class ArchiveEngine {
       { courseName: moodleCourse.fullname, moodleCourseId: moodleCourse.id },
       'No matching component found'
     );
+    return null;
+  }
+
+  private async matchComponentStrategies(
+    moodleCourse: MoodleCourse,
+    uniqueCandidates: string[],
+    uniqueTeacherIds: string[],
+    enrolledCodigos: string[] | undefined,
+    extraFilter: Record<string, unknown> = {}
+  ): Promise<ComponentDocument | null> {
+    const findByKeywords = async (
+      keywords: string[],
+      extraFilterInner: Record<string, unknown> = {}
+    ): Promise<ComponentDocument | null> =>
+      await this.componentsRepository.findByDisciplinaKeywords(
+        keywords,
+        extraFilterInner
+      );
+
+    const enrolledCodigosFilter =
+      enrolledCodigos && enrolledCodigos.length > 0
+        ? { codigo: { $in: enrolledCodigos } }
+        : {};
+
+    const isCodeAllowed =
+      enrolledCodigos && enrolledCodigos.length > 0
+        ? (code: string) => enrolledCodigos.includes(code)
+        : () => true;
+
+    // Strategy 1: candidate code + teacher
+    if (uniqueCandidates.length > 0) {
+      const teacherFilter =
+        uniqueTeacherIds.length > 0
+          ? {
+              $or: [
+                { teoria: { $in: uniqueTeacherIds } },
+                { pratica: { $in: uniqueTeacherIds } },
+              ],
+            }
+          : {};
+
+      for (const candidateCode of uniqueCandidates) {
+        if (!isCodeAllowed(candidateCode)) {
+          this.logger.info(
+            { candidateCode },
+            'Skipping candidate code not in enrollments'
+          );
+          continue;
+        }
+
+        const result = await this.componentsRepository.findByCodigo(
+          candidateCode,
+          { ...teacherFilter, ...extraFilter }
+        );
+
+        if (result) {
+          this.logger.info(
+            {
+              candidateCode,
+              componentDbId: result._id,
+              componentName: result.disciplina,
+              season: `${result.year}:${result.quad}`,
+            },
+            'Matched component by candidate code'
+          );
+          return result;
+        }
+      }
+
+      // Strategy 2: candidate code only
+      if (uniqueTeacherIds.length > 0) {
+        for (const candidateCode of uniqueCandidates) {
+          if (!isCodeAllowed(candidateCode)) {
+            continue;
+          }
+          const result = await this.componentsRepository.findByCodigo(
+            candidateCode,
+            extraFilter
+          );
+
+          if (result) {
+            this.logger.info(
+              {
+                candidateCode,
+                componentDbId: result._id,
+                componentName: result.disciplina,
+                season: `${result.year}:${result.quad}`,
+              },
+              'Matched component by candidate code (no teacher)'
+            );
+            return result;
+          }
+        }
+      }
+    }
+
+    // Strategy 3: disciplina keyword + teacher
+    if (uniqueTeacherIds.length > 0) {
+      const keywords = ArchiveEngine.extractKeywords(moodleCourse.fullname);
+      this.logger.info(
+        { keywords },
+        'No candidate match, trying disciplina keywords'
+      );
+
+      const match = await ArchiveEngine.relaxedKeywordSearch(
+        keywords,
+        {
+          $or: [
+            { teoria: { $in: uniqueTeacherIds } },
+            { pratica: { $in: uniqueTeacherIds } },
+          ],
+          ...extraFilter,
+          ...enrolledCodigosFilter,
+        },
+        findByKeywords
+      );
+
+      if (match) {
+        this.logger.info(
+          {
+            componentDbId: match.component._id,
+            componentName: match.component.disciplina,
+            keywords: match.keywordsUsed,
+            season: `${match.component.year}:${match.component.quad}`,
+          },
+          'Matched component by disciplina keywords'
+        );
+        return match.component;
+      }
+    }
+
+    // Strategy 4: disciplina keyword only
+    {
+      const keywords = ArchiveEngine.extractKeywords(moodleCourse.fullname);
+
+      const match = await ArchiveEngine.relaxedKeywordSearch(
+        keywords,
+        { ...extraFilter, ...enrolledCodigosFilter },
+        findByKeywords
+      );
+
+      if (match) {
+        this.logger.info(
+          {
+            componentDbId: match.component._id,
+            componentName: match.component.disciplina,
+            keywords: match.keywordsUsed,
+            season: `${match.component.year}:${match.component.quad}`,
+          },
+          'Matched component by disciplina keywords (no teacher)'
+        );
+        return match.component;
+      }
+    }
+
     return null;
   }
 

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -1,5 +1,6 @@
 import { findArchiveQuarter } from '@next/utils';
 import { load } from 'cheerio';
+import { createHash } from 'node:crypto';
 import { ofetch } from 'ofetch';
 
 import { MoodleConnector } from '@/connectors/moodle.js';
@@ -456,7 +457,8 @@ export class ArchiveEngine {
       let name = trimmedText;
       if (name === '') {
         const titleAttr = $(el).attr('title');
-        name = titleAttr !== undefined && titleAttr !== '' ? titleAttr : 'documento';
+        name =
+          titleAttr !== undefined && titleAttr !== '' ? titleAttr : 'documento';
       }
 
       if (
@@ -503,10 +505,14 @@ export class ArchiveEngine {
     const filename = this.extractFilenameFromUrl(url);
     const sanitizedFilename = ArchiveEngine.sanitizeFilename(filename);
     const s3Key = `/archives/${componentId}/${sanitizedFilename}`;
+    const checksum = createHash('sha256')
+      .update(Buffer.from(buffer))
+      .digest('hex');
 
     await this.s3Connector?.upload(bucket, s3Key, Buffer.from(buffer));
 
     return {
+      checksum,
       pdfName: sanitizedFilename,
       s3Key,
     };

--- a/apps/core/src/services/components-service.ts
+++ b/apps/core/src/services/components-service.ts
@@ -13,7 +13,8 @@ import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
 import { UserModel } from '@/models/User.js';
 import { logger as defaultLogger } from '@/utils/logger.js';
 
-import { ArchiveEngine, type MoodleSession } from './archive-engine.js';
+import { ArchiveEngine } from './archive-engine.js';
+import type { MoodleSession } from './archive-engine.js';
 
 export class ComponentsService {
   private readonly mapper = new ComponentMapper();
@@ -22,7 +23,6 @@ export class ComponentsService {
   private readonly manager?: JobManager<JobRegistry>;
 
   constructor({
-    requestId,
     manager,
     globalTraceId,
   }: {
@@ -30,7 +30,7 @@ export class ComponentsService {
     manager?: JobManager<JobRegistry>;
     globalTraceId?: string;
   }) {
-    this.logger = defaultLogger.child({ requestId, globalTraceId });
+    this.logger = defaultLogger.child({ globalTraceId });
     this.engine = new ArchiveEngine({ globalTraceId });
     this.manager = manager;
   }
@@ -64,9 +64,9 @@ export class ComponentsService {
 
     await this.manager?.dispatch(JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING, {
       component: data,
+      enrolledCodigos,
       globalTraceId,
       session,
-      enrolledCodigos,
     });
   }
 

--- a/apps/core/src/services/components-service.ts
+++ b/apps/core/src/services/components-service.ts
@@ -13,9 +13,9 @@ import type { JobRegistry } from '@/jobs/registry.js';
 import { ComponentArchiveMapper } from '@/mappers/component-archive-mapper.js';
 import { ComponentMapper } from '@/mappers/component-mapper.js';
 import { ComponentModel } from '@/models/Component.js';
-import { ComponentArchiveModel } from '@/models/ComponentArchive.js';
 import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
 import { UserModel } from '@/models/User.js';
+import { ComponentArchivesRepository } from '@/repositories/component-archives-repository.js';
 import { logger as defaultLogger } from '@/utils/logger.js';
 
 import { ArchiveEngine } from './archive-engine.js';
@@ -24,6 +24,7 @@ import type { MoodleSession } from './archive-engine.js';
 export class ComponentsService {
   private readonly mapper = new ComponentMapper();
   private readonly archiveMapper = new ComponentArchiveMapper();
+  private readonly archivesRepository: ComponentArchivesRepository;
   private readonly logger: ReturnType<typeof defaultLogger.child>;
   private readonly engine: ArchiveEngine;
   private readonly manager?: JobManager<JobRegistry>;
@@ -38,6 +39,9 @@ export class ComponentsService {
   }) {
     this.logger = defaultLogger.child({ globalTraceId });
     this.engine = new ArchiveEngine({ globalTraceId });
+    this.archivesRepository = new ComponentArchivesRepository({
+      globalTraceId,
+    });
     this.manager = manager;
   }
 
@@ -77,14 +81,8 @@ export class ComponentsService {
   }
 
   async listComponentArchives(componentId: string) {
-    this.logger.debug({ componentId }, 'Listing component archives');
-
-    const archives = await ComponentArchiveModel.find({
-      component: componentId,
-    })
-      .populate('component', 'disciplina codigo turma turno season')
-      .sort({ createdAt: -1 })
-      .lean();
+    const archives =
+      await this.archivesRepository.findByComponentId(componentId);
 
     return archives.map((archive) => this.archiveMapper.toResponse(archive));
   }
@@ -94,9 +92,7 @@ export class ComponentsService {
     s3Connector: S3Connector,
     bucket: string
   ) {
-    this.logger.debug({ archiveId }, 'Fetching archive for download');
-
-    const archive = await ComponentArchiveModel.findById(archiveId);
+    const archive = await this.archivesRepository.findById(archiveId);
 
     if (!archive || typeof archive.s3_key !== 'string') {
       throw new ArchiveNotFound();

--- a/apps/core/src/services/components-service.ts
+++ b/apps/core/src/services/components-service.ts
@@ -1,14 +1,19 @@
 import type { JobManager } from '@next/queues/manager';
 import { Types } from 'mongoose';
 
+import type { S3Connector } from '@/connectors/s3-connector.js';
 import { JOB_NAMES } from '@/constants.js';
 import {
+  ArchiveFileEmpty,
+  ArchiveNotFound,
   EmailVerificationFailed,
   UserWithoutRA,
 } from '@/errors/custom-errors.js';
 import type { JobRegistry } from '@/jobs/registry.js';
+import { ComponentArchiveMapper } from '@/mappers/component-archive-mapper.js';
 import { ComponentMapper } from '@/mappers/component-mapper.js';
 import { ComponentModel } from '@/models/Component.js';
+import { ComponentArchiveModel } from '@/models/ComponentArchive.js';
 import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
 import { UserModel } from '@/models/User.js';
 import { logger as defaultLogger } from '@/utils/logger.js';
@@ -18,6 +23,7 @@ import type { MoodleSession } from './archive-engine.js';
 
 export class ComponentsService {
   private readonly mapper = new ComponentMapper();
+  private readonly archiveMapper = new ComponentArchiveMapper();
   private readonly logger: ReturnType<typeof defaultLogger.child>;
   private readonly engine: ArchiveEngine;
   private readonly manager?: JobManager<JobRegistry>;
@@ -70,6 +76,45 @@ export class ComponentsService {
     });
   }
 
+  async listComponentArchives(componentId: string) {
+    this.logger.debug({ componentId }, 'Listing component archives');
+
+    const archives = await ComponentArchiveModel.find({
+      component: componentId,
+    })
+      .populate('component', 'disciplina codigo turma turno season')
+      .sort({ createdAt: -1 })
+      .lean();
+
+    return archives.map((archive) => this.archiveMapper.toResponse(archive));
+  }
+
+  async getArchiveDownload(
+    archiveId: string,
+    s3Connector: S3Connector,
+    bucket: string
+  ) {
+    this.logger.debug({ archiveId }, 'Fetching archive for download');
+
+    const archive = await ComponentArchiveModel.findById(archiveId);
+
+    if (!archive || typeof archive.s3_key !== 'string') {
+      throw new ArchiveNotFound();
+    }
+
+    const s3Object = await s3Connector.getObject(bucket, archive.s3_key);
+
+    if (!s3Object.Body) {
+      throw new ArchiveFileEmpty();
+    }
+
+    return {
+      body: s3Object.Body,
+      contentType: s3Object.ContentType ?? 'application/octet-stream',
+      filename: archive.file_name ?? 'document.pdf',
+    };
+  }
+
   async findComponentByIdOrOriginKey(id: string, withMetadata: boolean) {
     this.logger.debug({ id, withMetadata }, 'Looking up component');
 
@@ -89,7 +134,7 @@ export class ComponentsService {
     }
 
     let metadata = null;
-    if (withMetadata && component.origin_key) {
+    if (withMetadata && component?.origin_key != null) {
       metadata = await ComponentMetadataModel.findOne({
         'metadata.component_data.componentKey': component.origin_key,
       }).lean();

--- a/apps/core/src/services/components-service.ts
+++ b/apps/core/src/services/components-service.ts
@@ -2,10 +2,15 @@ import type { JobManager } from '@next/queues/manager';
 import { Types } from 'mongoose';
 
 import { JOB_NAMES } from '@/constants.js';
+import {
+  EmailVerificationFailed,
+  UserWithoutRA,
+} from '@/errors/custom-errors.js';
 import type { JobRegistry } from '@/jobs/registry.js';
 import { ComponentMapper } from '@/mappers/component-mapper.js';
 import { ComponentModel } from '@/models/Component.js';
 import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
+import { UserModel } from '@/models/User.js';
 import { logger as defaultLogger } from '@/utils/logger.js';
 
 import { ArchiveEngine, type MoodleSession } from './archive-engine.js';
@@ -28,6 +33,26 @@ export class ComponentsService {
     this.logger = defaultLogger.child({ requestId, globalTraceId });
     this.engine = new ArchiveEngine({ globalTraceId });
     this.manager = manager;
+  }
+
+  async verifyUserForArchives(session: MoodleSession) {
+    const email = await this.engine.getUserEmail(session.sessionId);
+
+    if (email === null) {
+      throw new EmailVerificationFailed();
+    }
+
+    const user = await UserModel.findOne({ email });
+
+    if (user?.ra === undefined || user.ra === null || user.ra === 0) {
+      this.logger.warn(
+        { email },
+        'User does not have RA, skipping enrollment check'
+      );
+      throw new UserWithoutRA();
+    }
+
+    return user;
   }
 
   async processComponentArchives(

--- a/apps/core/src/services/components-service.ts
+++ b/apps/core/src/services/components-service.ts
@@ -1,36 +1,48 @@
+import type { JobManager } from '@next/queues/manager';
 import { Types } from 'mongoose';
 
-import type { MoodleComponent } from '@/connectors/moodle.js';
+import { JOB_NAMES } from '@/constants.js';
+import type { JobRegistry } from '@/jobs/registry.js';
 import { ComponentMapper } from '@/mappers/component-mapper.js';
 import { ComponentModel } from '@/models/Component.js';
 import { ComponentMetadataModel } from '@/models/ComponentMetadata.js';
-import { componentArchiveSchema } from '@/schemas/v2/components.js';
 import { logger as defaultLogger } from '@/utils/logger.js';
+
+import { ArchiveEngine, type MoodleSession } from './archive-engine.js';
 
 export class ComponentsService {
   private readonly mapper = new ComponentMapper();
   private readonly logger: ReturnType<typeof defaultLogger.child>;
+  private readonly engine: ArchiveEngine;
+  private readonly manager?: JobManager<JobRegistry>;
 
-  constructor({ requestId }: { requestId: string }) {
-    this.logger = defaultLogger.child({ requestId });
+  constructor({
+    requestId,
+    manager,
+    globalTraceId,
+  }: {
+    requestId?: string;
+    manager?: JobManager<JobRegistry>;
+    globalTraceId?: string;
+  }) {
+    this.logger = defaultLogger.child({ requestId, globalTraceId });
+    this.engine = new ArchiveEngine({ globalTraceId });
+    this.manager = manager;
   }
 
-  async getComponentArchives(components: MoodleComponent | undefined) {
-    const componentArchives = componentArchiveSchema.safeParse(
-      components?.data.courses
-    );
+  async processComponentArchives(
+    session: MoodleSession,
+    globalTraceId?: string,
+    enrolledCodigos?: string[]
+  ) {
+    const data = await this.engine.fetchAndValidateCourses(session);
 
-    if (!componentArchives.success) {
-      return {
-        error: componentArchives.error.message,
-        data: null,
-      };
-    }
-
-    return {
-      error: null,
-      data: componentArchives.data,
-    };
+    await this.manager?.dispatch(JOB_NAMES.COMPONENTS_ARCHIVES_PROCESSING, {
+      component: data,
+      globalTraceId,
+      session,
+      enrolledCodigos,
+    });
   }
 
   async findComponentByIdOrOriginKey(id: string, withMetadata: boolean) {

--- a/apps/core/tests/integration/components/archives.spec.ts
+++ b/apps/core/tests/integration/components/archives.spec.ts
@@ -46,10 +46,11 @@ describe('Archive Flow Integration', () => {
 
     const pdfsRes = await app.inject({
       method: 'GET',
-      url: '/v2/components/archives/pdfs',
+      url: '/v2/components/archives/uploads',
     });
     const pdfs = JSON.parse(pdfsRes.body);
 
-    expect(pdfs.length).toBeGreaterThan(1);
+    expect(pdfs.status).toBe('success');
+    expect(pdfs.data.length).toBeGreaterThan(1);
   });
 });

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -54,9 +54,17 @@ export default defineConfig({
       },
       files: ['packages/**/*.ts'],
     },
+    {
+      files: ['**/*-controller.ts', '**/hooks/*.ts'],
+      rules: {
+        'func-style': 'off',
+        'require-await': 'off',
+      },
+    },
   ],
   rules: {
     complexity: ['error', 25],
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
     'eslint/complexity': ['error', { max: 35 }],
     'func-style': ['error', 'declaration'],
     'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -61,6 +61,13 @@ export default defineConfig({
         'require-await': 'off',
       },
     },
+    {
+      files: ['apps/core/src/connectors/**/*.ts'],
+      rules: {
+        'eslint/no-constructor-return': 'off',
+        'unicorn/no-this-assignment': 'off',
+      },
+    },
   ],
   rules: {
     complexity: ['error', 25],

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -75,6 +75,7 @@ export default defineConfig({
     'eslint/complexity': ['error', { max: 35 }],
     'func-style': ['error', 'declaration'],
     'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+    'no-eq-null': 'off',
     'typescript/array-type': ['error', { default: 'array-simple' }],
     'typescript/consistent-type-definitions': ['error', 'type'],
   },

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,8 +1,8 @@
-import type { FastifyInstance } from 'fastify';
+import { inspect } from 'node:util';
 
+import type { FastifyInstance } from 'fastify';
 import { fastifyPlugin as fp } from 'fastify-plugin';
 import mongoose, { type Mongoose, connect } from 'mongoose';
-import { inspect } from 'node:util';
 
 import { db, type DatabaseModels } from './models.js';
 
@@ -10,12 +10,20 @@ declare module 'fastify' {
   interface FastifyInstance {
     rawMongoose: Mongoose;
     db: DatabaseModels;
-    config: any;
   }
 }
 
+export type MongooseConnectorOptions = {
+  config: {
+    NODE_ENV: string;
+    LOG_LEVEL?: string;
+    MONGODB_CONNECTION_URL: string;
+  };
+};
+
 export default fp(
-  async (app: FastifyInstance) => {
+  async (app: FastifyInstance, options: MongooseConnectorOptions) => {
+    const { config } = options;
     try {
       mongoose.connection.on('connected', () => {
         app.log.info('[MONGO] Connected to instance');
@@ -30,7 +38,7 @@ export default fp(
       });
 
       const isLogDebug =
-        app.config.NODE_ENV === 'dev' && app.config.LOG_LEVEL === 'debug';
+        config.NODE_ENV === 'dev' && config.LOG_LEVEL === 'debug';
 
       if (isLogDebug) {
         mongoose.set('debug', (collection, method, query, doc, options) => {
@@ -51,11 +59,11 @@ export default fp(
         });
       }
 
-      await connect(app.config.MONGODB_CONNECTION_URL, {
+      await connect(config.MONGODB_CONNECTION_URL, {
         maxPoolSize: 10,
         serverSelectionTimeoutMS: 5000,
         socketTimeoutMS: 45000,
-        autoIndex: app.config.NODE_ENV === 'dev',
+        autoIndex: config.NODE_ENV === 'dev',
       });
 
       app.decorate('rawMongoose', mongoose);

--- a/packages/queues/src/builder.ts
+++ b/packages/queues/src/builder.ts
@@ -40,7 +40,7 @@ export type JobHandler<
   TData = unknown,
   TResult = unknown,
   TName extends string = string,
-> = (ctx: JobContext<TData, TResult, TName>) => Promise<TResult>;
+> = (ctx: JobContext<TData, TResult, TName>) => Promise<TResult> | TResult;
 
 export class JobBuilder<
   TName extends string,

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -13,12 +13,24 @@ export const moodleMock = {
               {
                 id: componentId,
                 fullname: componentName,
+                shortname: 'MCTA001-24',
+                idnumber: 'MCTA001',
+                startdate: 1706745600,
                 viewurl: `https://moodle.ufabc.edu.br/course/${componentId}`,
               },
             ],
           },
         },
       ]);
+
+    nock('https://moodle.ufabc.edu.br')
+      .get('/user/index.php')
+      .query(true)
+      .reply(
+        200,
+        `<html><body><table class="generaltable"><tr><td><a href="https://moodle.ufabc.edu.br/user/view.php?id=1&course=${componentId}">Teacher Name</a></td></tr></table></body></html>`,
+        { 'Content-Type': 'text/html' }
+      );
 
     nock('https://moodle.ufabc.edu.br')
       .get(`/course/${componentId}`)

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,3 +1,8 @@
-export { currentQuad, findQuarter, lastQuad } from './lib/findQuad.js';
+export {
+  currentQuad,
+  findArchiveQuarter,
+  findQuarter,
+  lastQuad,
+} from './lib/findQuad.js';
 export { generateIdentifier } from './lib/identifier.js';
 export { calculateCoefficients } from './lib/calculateCoefficients.js';

--- a/packages/utils/lib/findQuad.spec.ts
+++ b/packages/utils/lib/findQuad.spec.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { currentQuad, findQuadFromDate, findQuarter } from './findQuad';
+import {
+  currentQuad,
+  findArchiveQuadFromDate,
+  findArchiveQuarter,
+  findQuadFromDate,
+  findQuarter,
+} from './findQuad';
 
 describe('common.lib.findQuad', () => {
   it('should return 1 for January, February, November, and December', () => {
@@ -48,5 +54,53 @@ describe('common.lib.findQuad', () => {
     assert.deepEqual(currentQuad(new Date('2022-01-15')), '2022:1');
     assert.deepEqual(currentQuad(new Date('2022-04-15')), '2022:2');
     assert.deepEqual(currentQuad(new Date('2023-08-20')), '2023:3');
+  });
+
+  describe('findArchiveQuadFromDate', () => {
+    it('should return 1 for February, March, and April', () => {
+      assert.deepEqual(findArchiveQuadFromDate(1), 1);
+      assert.deepEqual(findArchiveQuadFromDate(2), 1);
+      assert.deepEqual(findArchiveQuadFromDate(3), 1);
+    });
+
+    it('should return 2 for May, June, July, and August', () => {
+      assert.deepEqual(findArchiveQuadFromDate(4), 2);
+      assert.deepEqual(findArchiveQuadFromDate(5), 2);
+      assert.deepEqual(findArchiveQuadFromDate(6), 2);
+      assert.deepEqual(findArchiveQuadFromDate(7), 2);
+    });
+
+    it('should return 3 for September through January', () => {
+      assert.deepEqual(findArchiveQuadFromDate(8), 3);
+      assert.deepEqual(findArchiveQuadFromDate(9), 3);
+      assert.deepEqual(findArchiveQuadFromDate(10), 3);
+      assert.deepEqual(findArchiveQuadFromDate(11), 3);
+      assert.deepEqual(findArchiveQuadFromDate(0), 3);
+    });
+  });
+
+  describe('findArchiveQuarter', () => {
+    it('should return null for an invalid date', () => {
+      assert.deepEqual(findArchiveQuarter(new Date('2000-23-34')), null);
+    });
+
+    it('should return the correct quarter and year for a given date', () => {
+      assert.deepStrictEqual(findArchiveQuarter(new Date('2022-03-15')), {
+        quad: 1,
+        year: 2022,
+      });
+      assert.deepStrictEqual(findArchiveQuarter(new Date('2022-06-15')), {
+        quad: 2,
+        year: 2022,
+      });
+      assert.deepStrictEqual(findArchiveQuarter(new Date('2022-12-20')), {
+        quad: 3,
+        year: 2022,
+      });
+      assert.deepStrictEqual(findArchiveQuarter(new Date('2023-01-05')), {
+        quad: 3,
+        year: 2023,
+      });
+    });
   });
 });

--- a/packages/utils/lib/findQuad.ts
+++ b/packages/utils/lib/findQuad.ts
@@ -1,7 +1,15 @@
 export function findQuadFromDate(month: number) {
-  if ([0, 1, 10, 11].includes(month)) return 1;
-  if ([2, 3, 4].includes(month)) return 2;
-  if ([5, 6, 7, 8, 9].includes(month)) return 3;
+  if ([0, 1, 10, 11].includes(month)) {
+    return 1;
+  }
+  if ([2, 3, 4].includes(month)) {
+    return 2;
+  }
+  if ([5, 6, 7, 8, 9].includes(month)) {
+    return 3;
+  }
+
+  throw new Error(`Invalid month: ${month}. Month must be between 0 and 11.`);
 }
 
 export function currentQuad(date?: Date): `${number}:${1 | 2 | 3}` {
@@ -45,18 +53,24 @@ export function lastQuad(date: Date = new Date()): FindQuarter {
   const season = findQuarter(date);
 
   if (season.quad === 1) {
-    return { year: season.year - 1, quad: 3 };
+    return { quad: 3, year: season.year - 1 };
   }
 
-  return { year: season.year, quad: (season.quad - 1) as FindQuarter['quad'] };
+  return { quad: (season.quad - 1) as FindQuarter['quad'], year: season.year };
 }
 
 // Archive matching uses a different quad boundary than the enrollment
 // calendar above: quad1 Feb-Apr, quad2 May-Aug, quad3 Sep-Jan.
 export function findArchiveQuadFromDate(month: number): 1 | 2 | 3 | undefined {
-  if (month >= 1 && month <= 3) return 1;
-  if (month >= 4 && month <= 7) return 2;
-  if (month >= 8 || month === 0) return 3;
+  if (month >= 1 && month <= 3) {
+    return 1;
+  }
+  if (month >= 4 && month <= 7) {
+    return 2;
+  }
+  if (month >= 8 || month === 0) {
+    return 3;
+  }
 }
 
 export function findArchiveQuarter(date: Date): FindQuarter | null {

--- a/packages/utils/lib/findQuad.ts
+++ b/packages/utils/lib/findQuad.ts
@@ -50,3 +50,25 @@ export function lastQuad(date: Date = new Date()): FindQuarter {
 
   return { year: season.year, quad: (season.quad - 1) as FindQuarter['quad'] };
 }
+
+// Archive matching uses a different quad boundary than the enrollment
+// calendar above: quad1 Feb-Apr, quad2 May-Aug, quad3 Sep-Jan.
+export function findArchiveQuadFromDate(month: number): 1 | 2 | 3 | undefined {
+  if (month >= 1 && month <= 3) return 1;
+  if (month >= 4 && month <= 7) return 2;
+  if (month >= 8 || month === 0) return 3;
+}
+
+export function findArchiveQuarter(date: Date): FindQuarter | null {
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const quad = findArchiveQuadFromDate(date.getMonth());
+
+  if (!quad) {
+    return null;
+  }
+
+  return { quad, year: date.getFullYear() };
+}


### PR DESCRIPTION
Reconstructs the archive engine from the legacy backend MR (ufabc-next-backend#244) into this monorepo.

Introduces an `ArchiveEngine` service that:
- Matches Moodle courses to internal components (candidate codes, teachers, disciplina keywords, season derivation)
- Extracts teacher names and PDF links from Moodle course pages
- Downloads and uploads archives to S3
- Persists them as `ComponentArchive` documents with a created/stored/failed status timeline

Supporting changes:
- New `ComponentArchive` model and custom `NextError` subclasses
- Shared `findTeacher` helper extracted into the Teacher model
- New Moodle connector methods (`getUserPage`, `getUsersByCoursePage`) and S3 `getObject`
- Archive processing jobs rewritten to use the engine
- New `GET /components/:componentId/archives` and download routes
- POST `/components/archives` now verifies the user email/RA before dispatching
