### PR TITLE
fix(core): rate-limit PDF downloads, lower pdfDownloadJob concurrency

### DIFF
--- a/apps/core/src/connectors/moodle.ts
+++ b/apps/core/src/connectors/moodle.ts
@@ -163,6 +163,20 @@ export class MoodleConnector extends BaseRequester {
     return response;
   }
 
+  async downloadFile(url: string, sessionId: string): Promise<ArrayBuffer> {
+    await this.rateLimit();
+
+    const headers = new Headers();
+    headers.set('Cookie', `MoodleSession=${sessionId}`);
+
+    const response = await this.request<ArrayBuffer>(url, {
+      headers,
+      responseType: 'arrayBuffer',
+    });
+
+    return response;
+  }
+
   private async rateLimit() {
     const now = Date.now();
     const timeSinceLastRequest = now - this.lastRequestTime;

--- a/apps/core/src/jobs/components-archive-processing-flow.ts
+++ b/apps/core/src/jobs/components-archive-processing-flow.ts
@@ -105,7 +105,7 @@ export const pdfDownloadJob = defineJob(
         .optional(),
     })
   )
-  .concurrency(10)
+  .concurrency(3)
   .handler(async ({ job, app }) => {
     const { rawUrl, componentDbId, globalTraceId, session } = job.data;
 

--- a/apps/core/src/jobs/components-archive-processing-flow.ts
+++ b/apps/core/src/jobs/components-archive-processing-flow.ts
@@ -129,11 +129,31 @@ export const pdfDownloadJob = defineJob(
     );
 
     try {
-      const { checksum, pdfName, s3Key } = await engine.downloadAndUpload(
+      const result = await engine.downloadAndUpload(
         rawUrl,
         componentDbId,
         app.config.AWS_BUCKET
       );
+
+      if (!result) {
+        await ComponentArchiveModel.findByIdAndUpdate(archive._id, {
+          $push: {
+            timeline: {
+              metadata: { reason: 'missing_session' },
+              status: 'failed',
+            },
+          },
+          $set: { status: 'failed' },
+        });
+
+        return {
+          archiveId: archive._id,
+          message: 'No Moodle session available, skipped download',
+          success: false,
+        };
+      }
+
+      const { checksum, pdfName, s3Key } = result;
 
       if (archive.checksum === checksum) {
         return {

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -491,10 +491,18 @@ export class ArchiveEngine {
   }
 
   async downloadAndUpload(rawUrl: string, componentId: string, bucket: string) {
+    if (!this.session) {
+      this.logger.warn(
+        { componentId, rawUrl },
+        'No Moodle session available, skipping PDF download'
+      );
+      return null;
+    }
+
     const url = new URL(rawUrl);
     const buffer = await this.moodleConnector.downloadFile(
       url.href,
-      this.session?.sessionId ?? ''
+      this.session.sessionId
     );
 
     const filename = this.extractFilenameFromUrl(url);

--- a/apps/core/src/services/archive-engine.ts
+++ b/apps/core/src/services/archive-engine.ts
@@ -1,7 +1,6 @@
 import { findArchiveQuarter } from '@next/utils';
 import { load } from 'cheerio';
 import { createHash } from 'node:crypto';
-import { ofetch } from 'ofetch';
 
 import { MoodleConnector } from '@/connectors/moodle.js';
 import type { S3Connector } from '@/connectors/s3-connector.js';
@@ -493,14 +492,10 @@ export class ArchiveEngine {
 
   async downloadAndUpload(rawUrl: string, componentId: string, bucket: string) {
     const url = new URL(rawUrl);
-    const headers: Record<string, string> = {};
-    if (this.session) {
-      headers.Cookie = `MoodleSession=${this.session.sessionId}`;
-    }
-    const buffer = await ofetch(url.href, {
-      headers,
-      responseType: 'arrayBuffer',
-    });
+    const buffer = await this.moodleConnector.downloadFile(
+      url.href,
+      this.session?.sessionId ?? ''
+    );
 
     const filename = this.extractFilenameFromUrl(url);
     const sanitizedFilename = ArchiveEngine.sanitizeFilename(filename);


### PR DESCRIPTION
Production queue data (`components_archives_processing_pdf`) showed a 50% job failure rate: 148/150 failed jobs were `<no response> fetch failed`, clustered into 8 Moodle sessions, with 2 sessions alone accounting for 62% of failures — the signature of Moodle dropping connections after a burst of parallel requests from the same session.

`ArchiveEngine.downloadAndUpload` fetched PDFs directly via `ofetch`, bypassing `MoodleConnector`'s existing rate limiter entirely. This adds `MoodleConnector.downloadFile`, routed through the connector's 300ms `rateLimit()` (shared process-wide via the singleton), and lowers `pdfDownloadJob`'s concurrency from 10 to 3 to cut burst pressure against a single Moodle session.
